### PR TITLE
Feature: Define RoleManager as interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,24 @@ RESTful | [keymatch_model.conf](https://github.com/casbin/casbin/blob/master/exa
 Deny-override | [rbac_model_with_deny.conf](https://github.com/casbin/casbin/blob/master/examples/rbac_model_with_deny.conf)  | [rbac_policy_with_deny.csv](https://github.com/casbin/casbin/blob/master/examples/rbac_policy_with_deny.csv)
 Priority | [priority_model.conf](https://github.com/casbin/casbin/blob/master/examples/priority_model.conf)  | [priority_policy.csv](https://github.com/casbin/casbin/blob/master/examples/priority_policy.csv)
 
+## RoleManager
+
+To use a custom RoleManager implementation.
+
+```go
+
+    type myCustomRoleManager struct {} // assumes the type satisfies the RoleManager interface
+
+    func newRoleManager() rbac.RoleManagerConstructor {
+        return func() rbac.RoleManager {
+            return &myCustomRoleManager{}
+        }
+    }
+
+    e := casbin.NewEnforcer("path/to/model.conf", "path/to/policy.csv")
+    e.SetRoleManager(newRoleManager())
+```
+
 ## How to use Casbin as a service?
 
 - [Go-Simple-API-Gateway](https://github.com/Soontao/go-simple-api-gateway): A simple API gateway written by golang, supports for authentication and authorization

--- a/enforcer.go
+++ b/enforcer.go
@@ -22,6 +22,7 @@ import (
 	"github.com/casbin/casbin/file-adapter"
 	"github.com/casbin/casbin/model"
 	"github.com/casbin/casbin/persist"
+	"github.com/casbin/casbin/rbac"
 	"github.com/casbin/casbin/util"
 )
 
@@ -40,6 +41,7 @@ type Enforcer struct {
 	modelPath string
 	model     model.Model
 	fm        model.FunctionMap
+	rmc       rbac.RoleManagerConstructor
 
 	adapter persist.Adapter
 
@@ -55,6 +57,7 @@ type Enforcer struct {
 // e := casbin.NewEnforcer("path/to/basic_model.conf", a)
 func NewEnforcer(params ...interface{}) *Enforcer {
 	e := &Enforcer{}
+	e.rmc = rbac.DefaultRoleManager()
 
 	parsedParamLen := 0
 	if len(params) >= 1 && reflect.TypeOf(params[len(params)-1]).Kind() == reflect.Bool {
@@ -182,6 +185,11 @@ func (e *Enforcer) SetAdapter(adapter persist.Adapter) {
 	e.adapter = adapter
 }
 
+// SetRoleManager sets the constructor function for creating a RoleManager.
+func (e *Enforcer) SetRoleManager(rmc rbac.RoleManagerConstructor) {
+	e.rmc = rmc
+}
+
 // ClearPolicy clears all policy.
 func (e *Enforcer) ClearPolicy() {
 	e.model.ClearPolicy()
@@ -196,7 +204,7 @@ func (e *Enforcer) LoadPolicy() error {
 	}
 
 	e.model.PrintPolicy()
-	e.model.BuildRoleLinks()
+	e.model.BuildRoleLinks(e.rmc)
 	return nil
 }
 

--- a/management_api.go
+++ b/management_api.go
@@ -144,7 +144,7 @@ func (e *Enforcer) AddGroupingPolicy(params ...interface{}) bool {
 		ruleAdded = e.addPolicy("g", "g", policy)
 	}
 
-	e.model.BuildRoleLinks()
+	e.model.BuildRoleLinks(e.rmc)
 	return ruleAdded
 }
 
@@ -162,14 +162,14 @@ func (e *Enforcer) RemoveGroupingPolicy(params ...interface{}) bool {
 		ruleRemoved = e.removePolicy("g", "g", policy)
 	}
 
-	e.model.BuildRoleLinks()
+	e.model.BuildRoleLinks(e.rmc)
 	return ruleRemoved
 }
 
 // RemoveFilteredGroupingPolicy removes a role inheritance rule from the current policy, field filters can be specified.
 func (e *Enforcer) RemoveFilteredGroupingPolicy(fieldIndex int, fieldValues ...string) bool {
 	ruleRemoved := e.removeFilteredPolicy("g", "g", fieldIndex, fieldValues...)
-	e.model.BuildRoleLinks()
+	e.model.BuildRoleLinks(e.rmc)
 	return ruleRemoved
 }
 

--- a/model/assertion.go
+++ b/model/assertion.go
@@ -26,11 +26,11 @@ type Assertion struct {
 	Value  string
 	Tokens []string
 	Policy [][]string
-	RM     *rbac.RoleManager
+	RM     rbac.RoleManager
 }
 
-func (ast *Assertion) buildRoleLinks() {
-	ast.RM = rbac.NewRoleManager(10)
+func (ast *Assertion) buildRoleLinks(rmc rbac.RoleManagerConstructor) {
+	ast.RM = rmc()
 	for _, rule := range ast.Policy {
 		if len(rule) == 2 {
 			ast.RM.AddLink(rule[0], rule[1])

--- a/model/policy.go
+++ b/model/policy.go
@@ -15,13 +15,14 @@
 package model
 
 import (
+	"github.com/casbin/casbin/rbac"
 	"github.com/casbin/casbin/util"
 )
 
 // BuildRoleLinks initializes the roles in RBAC.
-func (model Model) BuildRoleLinks() {
+func (model Model) BuildRoleLinks(rmc rbac.RoleManagerConstructor) {
 	for _, ast := range model["g"] {
-		ast.buildRoleLinks()
+		ast.buildRoleLinks(rmc)
 	}
 }
 

--- a/rbac/default_role_manager.go
+++ b/rbac/default_role_manager.go
@@ -1,0 +1,226 @@
+// Copyright 2017 The casbin Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rbac
+
+import (
+	"github.com/casbin/casbin/util"
+)
+
+type defaultRoleManager struct {
+	allRoles map[string]*Role
+	level    int
+}
+
+// DefaultRoleManager provides an implementation for the RoleManagerConstructor
+// that creates the default RoleManager as it was previously created.
+func DefaultRoleManager() RoleManagerConstructor {
+	return func() RoleManager {
+		return NewDefaultRoleManager(10)
+	}
+}
+
+// NewDefaultRoleManager is the constructor for creating an instance of the
+// default RoleManager implementation..
+func NewDefaultRoleManager(level int) RoleManager {
+	rm := defaultRoleManager{}
+	rm.allRoles = make(map[string]*Role)
+	rm.level = level
+	return &rm
+}
+
+func (rm *defaultRoleManager) hasRole(name string) bool {
+	_, ok := rm.allRoles[name]
+	return ok
+}
+
+func (rm *defaultRoleManager) createRole(name string) *Role {
+	if !rm.hasRole(name) {
+		rm.allRoles[name] = newRole(name)
+	}
+
+	return rm.allRoles[name]
+}
+
+// AddLink adds the inheritance link between role: name1 and role: name2.
+// aka role: name1 inherits role: name2.
+// domain is a prefix to the roles.
+func (rm *defaultRoleManager) AddLink(name1 string, name2 string, domain ...string) {
+	if len(domain) == 1 {
+		name1 = domain[0] + "::" + name1
+		name2 = domain[0] + "::" + name2
+	}
+
+	role1 := rm.createRole(name1)
+	role2 := rm.createRole(name2)
+	role1.addRole(role2)
+}
+
+// DeleteLink deletes the inheritance link between role: name1 and role: name2.
+// aka role: name1 does not inherit role: name2 any more.
+// domain is a prefix to the roles.
+func (rm *defaultRoleManager) DeleteLink(name1 string, name2 string, domain ...string) {
+	if len(domain) == 1 {
+		name1 = domain[0] + "::" + name1
+		name2 = domain[0] + "::" + name2
+	}
+
+	if !rm.hasRole(name1) || !rm.hasRole(name2) {
+		return
+	}
+
+	role1 := rm.createRole(name1)
+	role2 := rm.createRole(name2)
+	role1.deleteRole(role2)
+}
+
+// HasLink determines whether role: name1 inherits role: name2.
+// domain is a prefix to the roles.
+func (rm *defaultRoleManager) HasLink(name1 string, name2 string, domain ...string) bool {
+	if len(domain) == 1 {
+		name1 = domain[0] + "::" + name1
+		name2 = domain[0] + "::" + name2
+	}
+
+	if name1 == name2 {
+		return true
+	}
+
+	if !rm.hasRole(name1) || !rm.hasRole(name2) {
+		return false
+	}
+
+	role1 := rm.createRole(name1)
+	return role1.hasRole(name2, rm.level)
+}
+
+// GetRoles gets the roles that a subject inherits.
+// domain is a prefix to the roles.
+func (rm *defaultRoleManager) GetRoles(name string, domain ...string) []string {
+	if len(domain) == 1 {
+		name = domain[0] + "::" + name
+	}
+
+	if !rm.hasRole(name) {
+		return nil
+	}
+
+	roles := rm.createRole(name).getRoles()
+	if len(domain) == 1 {
+		for i := range roles {
+			roles[i] = roles[i][len(domain[0])+2:]
+		}
+	}
+	return roles
+}
+
+// GetUsers gets the users that inherits a subject.
+func (rm *defaultRoleManager) GetUsers(name string) []string {
+	if !rm.hasRole(name) {
+		return nil
+	}
+
+	names := []string{}
+	for _, role := range rm.allRoles {
+		if role.hasDirectRole(name) {
+			names = append(names, role.name)
+		}
+	}
+	return names
+}
+
+// PrintRoles prints all the roles to log.
+func (rm *defaultRoleManager) PrintRoles() {
+	for _, role := range rm.allRoles {
+		util.LogPrint(role.toString())
+	}
+}
+
+// Role represents the data structure for a role in RBAC.
+type Role struct {
+	name  string
+	roles []*Role
+}
+
+func newRole(name string) *Role {
+	r := Role{}
+	r.name = name
+	return &r
+}
+
+func (r *Role) addRole(role *Role) {
+	for _, rr := range r.roles {
+		if rr.name == role.name {
+			return
+		}
+	}
+
+	r.roles = append(r.roles, role)
+}
+
+func (r *Role) deleteRole(role *Role) {
+	for i, rr := range r.roles {
+		if rr.name == role.name {
+			r.roles = append(r.roles[:i], r.roles[i+1:]...)
+			return
+		}
+	}
+}
+
+func (r *Role) hasRole(name string, level int) bool {
+	if r.name == name {
+		return true
+	}
+
+	if level <= 0 {
+		return false
+	}
+
+	for _, role := range r.roles {
+		if role.hasRole(name, level-1) {
+			return true
+		}
+	}
+	return false
+}
+
+func (r *Role) hasDirectRole(name string) bool {
+	for _, role := range r.roles {
+		if role.name == name {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (r *Role) toString() string {
+	names := ""
+	for i, role := range r.roles {
+		if i == 0 {
+			names += role.name
+		} else {
+			names += ", " + role.name
+		}
+	}
+	return r.name + " < " + names
+}
+
+func (r *Role) getRoles() []string {
+	names := []string{}
+	for _, role := range r.roles {
+		names = append(names, role.name)
+	}
+	return names
+}

--- a/rbac/default_role_manager_test.go
+++ b/rbac/default_role_manager_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/casbin/casbin/util"
 )
 
-func testRole(t *testing.T, rm *RoleManager, name1 string, name2 string, res bool) {
+func testRole(t *testing.T, rm RoleManager, name1 string, name2 string, res bool) {
 	myRes := rm.HasLink(name1, name2)
 	log.Printf("%s, %s: %t", name1, name2, myRes)
 
@@ -30,7 +30,7 @@ func testRole(t *testing.T, rm *RoleManager, name1 string, name2 string, res boo
 	}
 }
 
-func testDomainRole(t *testing.T, rm *RoleManager, name1 string, name2 string, domain string, res bool) {
+func testDomainRole(t *testing.T, rm RoleManager, name1 string, name2 string, domain string, res bool) {
 	myRes := rm.HasLink(name1, name2, domain)
 	log.Printf("%s :: %s, %s: %t", domain, name1, name2, myRes)
 
@@ -39,7 +39,7 @@ func testDomainRole(t *testing.T, rm *RoleManager, name1 string, name2 string, d
 	}
 }
 
-func testPrintRoles(t *testing.T, rm *RoleManager, name string, res []string) {
+func testPrintRoles(t *testing.T, rm RoleManager, name string, res []string) {
 	myRes := rm.GetRoles(name)
 	log.Printf("%s: %s", name, myRes)
 
@@ -49,7 +49,7 @@ func testPrintRoles(t *testing.T, rm *RoleManager, name string, res []string) {
 }
 
 func TestRole(t *testing.T) {
-	rm := NewRoleManager(3)
+	rm := NewDefaultRoleManager(3)
 	rm.AddLink("u1", "g1")
 	rm.AddLink("u2", "g1")
 	rm.AddLink("u3", "g2")
@@ -118,7 +118,7 @@ func TestRole(t *testing.T) {
 }
 
 func TestDomainRole(t *testing.T) {
-	rm := NewRoleManager(3)
+	rm := NewDefaultRoleManager(3)
 	rm.AddLink("u1", "g1", "domain1")
 	rm.AddLink("u2", "g1", "domain1")
 	rm.AddLink("u3", "admin", "domain2")

--- a/rbac/role_manager.go
+++ b/rbac/role_manager.go
@@ -14,205 +14,25 @@
 
 package rbac
 
-import (
-	"github.com/casbin/casbin/util"
-)
-
-// RoleManager represents the interface to manage the roles in RBAC.
-type RoleManager struct {
-	allRoles map[string]*Role
-	level    int
+// RoleManager provides interface to define the operations for managing roles.
+type RoleManager interface {
+	// AddLink adds the inheritance link between two roles. role: name1 and role: name2.
+	// domain is a prefix to the roles.
+	AddLink(name1 string, name2 string, domain ...string)
+	// DeleteLink deletes the inheritance link between two roles. role: name1 and role: name2.
+	// domain is a prefix to the roles.
+	DeleteLink(name1 string, name2 string, domain ...string)
+	// HasLink determines whether a link exists between two roles. role: name1 inherits role: name2.
+	// domain is a prefix to the roles.
+	HasLink(name1 string, name2 string, domain ...string) bool
+	// GetRoles gets the roles that a user inherits.
+	// domain is a prefix to the roles.
+	GetRoles(name string, domain ...string) []string
+	// GetUsers gets the users that inherits a role.
+	GetUsers(name string) []string
+	// PrintRoles prints all the roles to log.
+	PrintRoles()
 }
 
-// NewRoleManager is the constructor for RoleManager.
-func NewRoleManager(level int) *RoleManager {
-	rm := RoleManager{}
-	rm.allRoles = make(map[string]*Role)
-	rm.level = level
-	return &rm
-}
-
-func (rm *RoleManager) hasRole(name string) bool {
-	_, ok := rm.allRoles[name]
-	return ok
-}
-
-func (rm *RoleManager) createRole(name string) *Role {
-	if !rm.hasRole(name) {
-		rm.allRoles[name] = newRole(name)
-	}
-
-	return rm.allRoles[name]
-}
-
-// AddLink adds the inheritance link between role: name1 and role: name2.
-// aka role: name1 inherits role: name2.
-// domain is a prefix to the roles.
-func (rm *RoleManager) AddLink(name1 string, name2 string, domain ...string) {
-	if len(domain) == 1 {
-		name1 = domain[0] + "::" + name1
-		name2 = domain[0] + "::" + name2
-	}
-
-	role1 := rm.createRole(name1)
-	role2 := rm.createRole(name2)
-	role1.addRole(role2)
-}
-
-// DeleteLink deletes the inheritance link between role: name1 and role: name2.
-// aka role: name1 does not inherit role: name2 any more.
-// domain is a prefix to the roles.
-func (rm *RoleManager) DeleteLink(name1 string, name2 string, domain ...string) {
-	if len(domain) == 1 {
-		name1 = domain[0] + "::" + name1
-		name2 = domain[0] + "::" + name2
-	}
-
-	if !rm.hasRole(name1) || !rm.hasRole(name2) {
-		return
-	}
-
-	role1 := rm.createRole(name1)
-	role2 := rm.createRole(name2)
-	role1.deleteRole(role2)
-}
-
-// HasLink determines whether role: name1 inherits role: name2.
-// domain is a prefix to the roles.
-func (rm *RoleManager) HasLink(name1 string, name2 string, domain ...string) bool {
-	if len(domain) == 1 {
-		name1 = domain[0] + "::" + name1
-		name2 = domain[0] + "::" + name2
-	}
-
-	if name1 == name2 {
-		return true
-	}
-
-	if !rm.hasRole(name1) || !rm.hasRole(name2) {
-		return false
-	}
-
-	role1 := rm.createRole(name1)
-	return role1.hasRole(name2, rm.level)
-}
-
-// GetRoles gets the roles that a subject inherits.
-// domain is a prefix to the roles.
-func (rm *RoleManager) GetRoles(name string, domain ...string) []string {
-	if len(domain) == 1 {
-		name = domain[0] + "::" + name
-	}
-
-	if !rm.hasRole(name) {
-		return nil
-	}
-
-	roles := rm.createRole(name).getRoles()
-	if len(domain) == 1 {
-		for i := range roles {
-			roles[i] = roles[i][len(domain[0]) + 2:]
-		}
-	}
-	return roles
-}
-
-// GetUsers gets the users that inherits a subject.
-func (rm *RoleManager) GetUsers(name string) []string {
-	if !rm.hasRole(name) {
-		return nil
-	}
-
-	names := []string{}
-	for _, role := range rm.allRoles {
-		if role.hasDirectRole(name) {
-			names = append(names, role.name)
-		}
-	}
-	return names
-}
-
-// PrintRoles prints all the roles to log.
-func (rm *RoleManager) PrintRoles() {
-	for _, role := range rm.allRoles {
-		util.LogPrint(role.toString())
-	}
-}
-
-// Role represents the data structure for a role in RBAC.
-type Role struct {
-	name  string
-	roles []*Role
-}
-
-func newRole(name string) *Role {
-	r := Role{}
-	r.name = name
-	return &r
-}
-
-func (r *Role) addRole(role *Role) {
-	for _, rr := range r.roles {
-		if rr.name == role.name {
-			return
-		}
-	}
-
-	r.roles = append(r.roles, role)
-}
-
-func (r *Role) deleteRole(role *Role) {
-	for i, rr := range r.roles {
-		if rr.name == role.name {
-			r.roles = append(r.roles[:i], r.roles[i+1:]...)
-			return
-		}
-	}
-}
-
-func (r *Role) hasRole(name string, level int) bool {
-	if r.name == name {
-		return true
-	}
-
-	if level <= 0 {
-		return false
-	}
-
-	for _, role := range r.roles {
-		if role.hasRole(name, level-1) {
-			return true
-		}
-	}
-	return false
-}
-
-func (r *Role) hasDirectRole(name string) bool {
-	for _, role := range r.roles {
-		if role.name == name {
-			return true
-		}
-	}
-
-	return false
-}
-
-func (r *Role) toString() string {
-	names := ""
-	for i, role := range r.roles {
-		if i == 0 {
-			names += role.name
-		} else {
-			names += ", " + role.name
-		}
-	}
-	return r.name + " < " + names
-}
-
-func (r *Role) getRoles() []string {
-	names := []string{}
-	for _, role := range r.roles {
-		names = append(names, role.name)
-	}
-	return names
-}
+// RoleManagerConstructor provides a definition for constructing a RoleManager.
+type RoleManagerConstructor func() RoleManager


### PR DESCRIPTION
Define RoleManager as interface, and rename existing RoleManager struct
to defaultRoleManager to provide a default implementation and backwards
compatability.

Defines RoleManagerConstructor to allow specifying a function for
creating a new RoleManager.

Adds SetRoleManagerConstructor method to Model to allow setting the
function to call for a new instance of RoleManager.
Adds implementation of RoleManagerConstructor to Model that will create
an instance of the defaultRoleManager just like before.

Updates Assertion to reference RoleManager interface instead of an
instance. Updates Assertions.buildRoleLinks() to use newRoleManagerFunc
that holds the RoleManagerConstructor.

All test are passing with the only change being *RoleManager to
RoleManager.

Resolves #36 