### PR TITLE
[feature] Enable multiple policies/roles in API

### DIFF
--- a/management_api.go
+++ b/management_api.go
@@ -24,8 +24,8 @@ func (e *Enforcer) GetAllSubjects() []string {
 }
 
 // GetAllNamedSubjects gets the list of subjects that show up in the current named policy.
-func (e *Enforcer) GetAllNamedSubjects(name string) []string {
-	return e.model.GetValuesForFieldInPolicy("p", name, 0)
+func (e *Enforcer) GetAllNamedSubjects(ptype string) []string {
+	return e.model.GetValuesForFieldInPolicy("p", ptype, 0)
 }
 
 // GetAllObjects gets the list of objects that show up in the current policy.
@@ -34,8 +34,8 @@ func (e *Enforcer) GetAllObjects() []string {
 }
 
 // GetAllNamedObjects gets the list of objects that show up in the current named policy.
-func (e *Enforcer) GetAllNamedObjects(name string) []string {
-	return e.model.GetValuesForFieldInPolicy("p", name, 1)
+func (e *Enforcer) GetAllNamedObjects(ptype string) []string {
+	return e.model.GetValuesForFieldInPolicy("p", ptype, 1)
 }
 
 // GetAllActions gets the list of actions that show up in the current policy.
@@ -44,8 +44,8 @@ func (e *Enforcer) GetAllActions() []string {
 }
 
 // GetAllNamedActions gets the list of actions that show up in the current named policy.
-func (e *Enforcer) GetAllNamedActions(name string) []string {
-	return e.model.GetValuesForFieldInPolicy("p", name, 2)
+func (e *Enforcer) GetAllNamedActions(ptype string) []string {
+	return e.model.GetValuesForFieldInPolicy("p", ptype, 2)
 }
 
 // GetAllRoles gets the list of roles that show up in the current policy.
@@ -54,8 +54,8 @@ func (e *Enforcer) GetAllRoles() []string {
 }
 
 // GetAllNamedRoles gets the list of roles that show up in the current named policy.
-func (e *Enforcer) GetAllNamedRoles(name string) []string {
-	return e.model.GetValuesForFieldInPolicy("g", name, 1)
+func (e *Enforcer) GetAllNamedRoles(ptype string) []string {
+	return e.model.GetValuesForFieldInPolicy("g", ptype, 1)
 }
 
 // GetPolicy gets all the authorization rules in the policy.
@@ -69,13 +69,13 @@ func (e *Enforcer) GetFilteredPolicy(fieldIndex int, fieldValues ...string) [][]
 }
 
 // GetNamedPolicy gets all the authorization rules in the named policy.
-func (e *Enforcer) GetNamedPolicy(name string) [][]string {
-	return e.model.GetPolicy("p", name)
+func (e *Enforcer) GetNamedPolicy(ptype string) [][]string {
+	return e.model.GetPolicy("p", ptype)
 }
 
 // GetFilteredNamedPolicy gets all the authorization rules in the named policy, field filters can be specified.
-func (e *Enforcer) GetFilteredNamedPolicy(name string, fieldIndex int, fieldValues ...string) [][]string {
-	return e.model.GetFilteredPolicy("p", name, fieldIndex, fieldValues...)
+func (e *Enforcer) GetFilteredNamedPolicy(ptype string, fieldIndex int, fieldValues ...string) [][]string {
+	return e.model.GetFilteredPolicy("p", ptype, fieldIndex, fieldValues...)
 }
 
 // GetGroupingPolicy gets all the role inheritance rules in the policy.
@@ -89,13 +89,13 @@ func (e *Enforcer) GetFilteredGroupingPolicy(fieldIndex int, fieldValues ...stri
 }
 
 // GetNamedGroupingPolicy gets all the role inheritance rules in the policy.
-func (e *Enforcer) GetNamedGroupingPolicy(name string) [][]string {
-	return e.model.GetPolicy("g", name)
+func (e *Enforcer) GetNamedGroupingPolicy(ptype string) [][]string {
+	return e.model.GetPolicy("g", ptype)
 }
 
 // GetFilteredNamedGroupingPolicy gets all the role inheritance rules in the policy, field filters can be specified.
-func (e *Enforcer) GetFilteredNamedGroupingPolicy(name string, fieldIndex int, fieldValues ...string) [][]string {
-	return e.model.GetFilteredPolicy("g", name, fieldIndex, fieldValues...)
+func (e *Enforcer) GetFilteredNamedGroupingPolicy(ptype string, fieldIndex int, fieldValues ...string) [][]string {
+	return e.model.GetFilteredPolicy("g", ptype, fieldIndex, fieldValues...)
 }
 
 // HasPolicy determines whether an authorization rule exists.
@@ -104,9 +104,9 @@ func (e *Enforcer) HasPolicy(params ...interface{}) bool {
 }
 
 // HasNamedPolicy determines whether a named authorization rule exists.
-func (e *Enforcer) HasNamedPolicy(name string, params ...interface{}) bool {
+func (e *Enforcer) HasNamedPolicy(ptype string, params ...interface{}) bool {
 	if len(params) == 1 && reflect.TypeOf(params[0]).Kind() == reflect.Slice {
-		return e.model.HasPolicy("p", name, params[0].([]string))
+		return e.model.HasPolicy("p", ptype, params[0].([]string))
 	}
 
 	policy := make([]string, 0)
@@ -114,7 +114,7 @@ func (e *Enforcer) HasNamedPolicy(name string, params ...interface{}) bool {
 		policy = append(policy, param.(string))
 	}
 
-	return e.model.HasPolicy("p", name, policy)
+	return e.model.HasPolicy("p", ptype, policy)
 }
 
 // AddPolicy adds an authorization rule to the current policy.
@@ -127,17 +127,17 @@ func (e *Enforcer) AddPolicy(params ...interface{}) bool {
 // AddNamedPolicy adds an authorization rule to the current named policy.
 // If the rule already exists, the function returns false and the rule will not be added.
 // Otherwise the function returns true by adding the new rule.
-func (e *Enforcer) AddNamedPolicy(name string, params ...interface{}) bool {
+func (e *Enforcer) AddNamedPolicy(ptype string, params ...interface{}) bool {
 	ruleAdded := false
 	if len(params) == 1 && reflect.TypeOf(params[0]).Kind() == reflect.Slice {
-		ruleAdded = e.addPolicy("p", name, params[0].([]string))
+		ruleAdded = e.addPolicy("p", ptype, params[0].([]string))
 	} else {
 		policy := make([]string, 0)
 		for _, param := range params {
 			policy = append(policy, param.(string))
 		}
 
-		ruleAdded = e.addPolicy("p", name, policy)
+		ruleAdded = e.addPolicy("p", ptype, policy)
 	}
 
 	return ruleAdded
@@ -154,25 +154,25 @@ func (e *Enforcer) RemoveFilteredPolicy(fieldIndex int, fieldValues ...string) b
 }
 
 // RemoveNamedPolicy removes an authorization rule from the current named policy.
-func (e *Enforcer) RemoveNamedPolicy(name string, params ...interface{}) bool {
+func (e *Enforcer) RemoveNamedPolicy(ptype string, params ...interface{}) bool {
 	ruleRemoved := false
 	if len(params) == 1 && reflect.TypeOf(params[0]).Kind() == reflect.Slice {
-		ruleRemoved = e.removePolicy("p", name, params[0].([]string))
+		ruleRemoved = e.removePolicy("p", ptype, params[0].([]string))
 	} else {
 		policy := make([]string, 0)
 		for _, param := range params {
 			policy = append(policy, param.(string))
 		}
 
-		ruleRemoved = e.removePolicy("p", name, policy)
+		ruleRemoved = e.removePolicy("p", ptype, policy)
 	}
 
 	return ruleRemoved
 }
 
 // RemoveFilteredNamedPolicy removes an authorization rule from the current named policy, field filters can be specified.
-func (e *Enforcer) RemoveFilteredNamedPolicy(name string, fieldIndex int, fieldValues ...string) bool {
-	ruleRemoved := e.removeFilteredPolicy("p", name, fieldIndex, fieldValues...)
+func (e *Enforcer) RemoveFilteredNamedPolicy(ptype string, fieldIndex int, fieldValues ...string) bool {
+	ruleRemoved := e.removeFilteredPolicy("p", ptype, fieldIndex, fieldValues...)
 	return ruleRemoved
 }
 
@@ -182,9 +182,9 @@ func (e *Enforcer) HasGroupingPolicy(params ...interface{}) bool {
 }
 
 // HasNamedGroupingPolicy determines whether a named role inheritance rule exists.
-func (e *Enforcer) HasNamedGroupingPolicy(name string, params ...interface{}) bool {
+func (e *Enforcer) HasNamedGroupingPolicy(ptype string, params ...interface{}) bool {
 	if len(params) == 1 && reflect.TypeOf(params[0]).Kind() == reflect.Slice {
-		return e.model.HasPolicy("g", name, params[0].([]string))
+		return e.model.HasPolicy("g", ptype, params[0].([]string))
 	}
 
 	policy := make([]string, 0)
@@ -192,7 +192,7 @@ func (e *Enforcer) HasNamedGroupingPolicy(name string, params ...interface{}) bo
 		policy = append(policy, param.(string))
 	}
 
-	return e.model.HasPolicy("g", name, policy)
+	return e.model.HasPolicy("g", ptype, policy)
 }
 
 // AddGroupingPolicy adds a role inheritance rule to the current policy.
@@ -205,17 +205,17 @@ func (e *Enforcer) AddGroupingPolicy(params ...interface{}) bool {
 // AddNamedGroupingPolicy adds a named role inheritance rule to the current policy.
 // If the rule already exists, the function returns false and the rule will not be added.
 // Otherwise the function returns true by adding the new rule.
-func (e *Enforcer) AddNamedGroupingPolicy(name string, params ...interface{}) bool {
+func (e *Enforcer) AddNamedGroupingPolicy(ptype string, params ...interface{}) bool {
 	ruleAdded := false
 	if len(params) == 1 && reflect.TypeOf(params[0]).Kind() == reflect.Slice {
-		ruleAdded = e.addPolicy("g", name, params[0].([]string))
+		ruleAdded = e.addPolicy("g", ptype, params[0].([]string))
 	} else {
 		policy := make([]string, 0)
 		for _, param := range params {
 			policy = append(policy, param.(string))
 		}
 
-		ruleAdded = e.addPolicy("g", name, policy)
+		ruleAdded = e.addPolicy("g", ptype, policy)
 	}
 
 	e.model.BuildRoleLinks(e.rmc)
@@ -233,17 +233,17 @@ func (e *Enforcer) RemoveFilteredGroupingPolicy(fieldIndex int, fieldValues ...s
 }
 
 // RemoveNamedGroupingPolicy removes a role inheritance rule from the current named policy.
-func (e *Enforcer) RemoveNamedGroupingPolicy(name string, params ...interface{}) bool {
+func (e *Enforcer) RemoveNamedGroupingPolicy(ptype string, params ...interface{}) bool {
 	ruleRemoved := false
 	if len(params) == 1 && reflect.TypeOf(params[0]).Kind() == reflect.Slice {
-		ruleRemoved = e.removePolicy("g", name, params[0].([]string))
+		ruleRemoved = e.removePolicy("g", ptype, params[0].([]string))
 	} else {
 		policy := make([]string, 0)
 		for _, param := range params {
 			policy = append(policy, param.(string))
 		}
 
-		ruleRemoved = e.removePolicy("g", name, policy)
+		ruleRemoved = e.removePolicy("g", ptype, policy)
 	}
 
 	e.model.BuildRoleLinks(e.rmc)
@@ -251,13 +251,13 @@ func (e *Enforcer) RemoveNamedGroupingPolicy(name string, params ...interface{})
 }
 
 // RemoveFilteredNamedGroupingPolicy removes a role inheritance rule from the current named policy, field filters can be specified.
-func (e *Enforcer) RemoveFilteredNamedGroupingPolicy(name string, fieldIndex int, fieldValues ...string) bool {
-	ruleRemoved := e.removeFilteredPolicy("g", name, fieldIndex, fieldValues...)
+func (e *Enforcer) RemoveFilteredNamedGroupingPolicy(ptype string, fieldIndex int, fieldValues ...string) bool {
+	ruleRemoved := e.removeFilteredPolicy("g", ptype, fieldIndex, fieldValues...)
 	e.model.BuildRoleLinks(e.rmc)
 	return ruleRemoved
 }
 
 // AddFunction adds a customized function.
-func (e *Enforcer) AddFunction(name string, function func(args ...interface{}) (interface{}, error)) {
-	e.fm.AddFunction(name, function)
+func (e *Enforcer) AddFunction(ptype string, function func(args ...interface{}) (interface{}, error)) {
+	e.fm.AddFunction(ptype, function)
 }

--- a/management_api.go
+++ b/management_api.go
@@ -20,48 +20,93 @@ import (
 
 // GetAllSubjects gets the list of subjects that show up in the current policy.
 func (e *Enforcer) GetAllSubjects() []string {
-	return e.model.GetValuesForFieldInPolicy("p", "p", 0)
+	return e.GetAllNamedSubjects("p")
+}
+
+// GetAllNamedSubjects gets the list of subjects that show up in the current named policy.
+func (e *Enforcer) GetAllNamedSubjects(name string) []string {
+	return e.model.GetValuesForFieldInPolicy("p", name, 0)
 }
 
 // GetAllObjects gets the list of objects that show up in the current policy.
 func (e *Enforcer) GetAllObjects() []string {
-	return e.model.GetValuesForFieldInPolicy("p", "p", 1)
+	return e.GetAllNamedObjects("p")
+}
+
+// GetAllNamedObjects gets the list of objects that show up in the current named policy.
+func (e *Enforcer) GetAllNamedObjects(name string) []string {
+	return e.model.GetValuesForFieldInPolicy("p", name, 1)
 }
 
 // GetAllActions gets the list of actions that show up in the current policy.
 func (e *Enforcer) GetAllActions() []string {
-	return e.model.GetValuesForFieldInPolicy("p", "p", 2)
+	return e.GetAllNamedActions("p")
+}
+
+// GetAllNamedActions gets the list of actions that show up in the current named policy.
+func (e *Enforcer) GetAllNamedActions(name string) []string {
+	return e.model.GetValuesForFieldInPolicy("p", name, 2)
 }
 
 // GetAllRoles gets the list of roles that show up in the current policy.
 func (e *Enforcer) GetAllRoles() []string {
-	return e.model.GetValuesForFieldInPolicy("g", "g", 1)
+	return e.GetAllNamedRoles("g")
+}
+
+// GetAllNamedRoles gets the list of roles that show up in the current named policy.
+func (e *Enforcer) GetAllNamedRoles(name string) []string {
+	return e.model.GetValuesForFieldInPolicy("g", name, 1)
 }
 
 // GetPolicy gets all the authorization rules in the policy.
 func (e *Enforcer) GetPolicy() [][]string {
-	return e.model.GetPolicy("p", "p")
+	return e.GetNamedPolicy("p")
 }
 
 // GetFilteredPolicy gets all the authorization rules in the policy, field filters can be specified.
 func (e *Enforcer) GetFilteredPolicy(fieldIndex int, fieldValues ...string) [][]string {
-	return e.model.GetFilteredPolicy("p", "p", fieldIndex, fieldValues...)
+	return e.GetFilteredNamedPolicy("p", fieldIndex, fieldValues...)
+}
+
+// GetNamedPolicy gets all the authorization rules in the named policy.
+func (e *Enforcer) GetNamedPolicy(name string) [][]string {
+	return e.model.GetPolicy("p", name)
+}
+
+// GetFilteredNamedPolicy gets all the authorization rules in the named policy, field filters can be specified.
+func (e *Enforcer) GetFilteredNamedPolicy(name string, fieldIndex int, fieldValues ...string) [][]string {
+	return e.model.GetFilteredPolicy("p", name, fieldIndex, fieldValues...)
 }
 
 // GetGroupingPolicy gets all the role inheritance rules in the policy.
 func (e *Enforcer) GetGroupingPolicy() [][]string {
-	return e.model.GetPolicy("g", "g")
+	return e.GetNamedGroupingPolicy("g")
 }
 
 // GetFilteredGroupingPolicy gets all the role inheritance rules in the policy, field filters can be specified.
 func (e *Enforcer) GetFilteredGroupingPolicy(fieldIndex int, fieldValues ...string) [][]string {
-	return e.model.GetFilteredPolicy("g", "g", fieldIndex, fieldValues...)
+	return e.GetFilteredNamedGroupingPolicy("g", fieldIndex, fieldValues...)
+}
+
+// GetNamedGroupingPolicy gets all the role inheritance rules in the policy.
+func (e *Enforcer) GetNamedGroupingPolicy(name string) [][]string {
+	return e.model.GetPolicy("g", name)
+}
+
+// GetFilteredNamedGroupingPolicy gets all the role inheritance rules in the policy, field filters can be specified.
+func (e *Enforcer) GetFilteredNamedGroupingPolicy(name string, fieldIndex int, fieldValues ...string) [][]string {
+	return e.model.GetFilteredPolicy("g", name, fieldIndex, fieldValues...)
 }
 
 // HasPolicy determines whether an authorization rule exists.
 func (e *Enforcer) HasPolicy(params ...interface{}) bool {
+	return e.HasNamedPolicy("p", params...)
+}
+
+// HasNamedPolicy determines whether a named authorization rule exists.
+func (e *Enforcer) HasNamedPolicy(name string, params ...interface{}) bool {
 	if len(params) == 1 && reflect.TypeOf(params[0]).Kind() == reflect.Slice {
-		return e.model.HasPolicy("p", "p", params[0].([]string))
+		return e.model.HasPolicy("p", name, params[0].([]string))
 	}
 
 	policy := make([]string, 0)
@@ -69,23 +114,30 @@ func (e *Enforcer) HasPolicy(params ...interface{}) bool {
 		policy = append(policy, param.(string))
 	}
 
-	return e.model.HasPolicy("p", "p", policy)
+	return e.model.HasPolicy("p", name, policy)
 }
 
 // AddPolicy adds an authorization rule to the current policy.
 // If the rule already exists, the function returns false and the rule will not be added.
 // Otherwise the function returns true by adding the new rule.
 func (e *Enforcer) AddPolicy(params ...interface{}) bool {
+	return e.AddNamedPolicy("p", params...)
+}
+
+// AddNamedPolicy adds an authorization rule to the current named policy.
+// If the rule already exists, the function returns false and the rule will not be added.
+// Otherwise the function returns true by adding the new rule.
+func (e *Enforcer) AddNamedPolicy(name string, params ...interface{}) bool {
 	ruleAdded := false
 	if len(params) == 1 && reflect.TypeOf(params[0]).Kind() == reflect.Slice {
-		ruleAdded = e.addPolicy("p", "p", params[0].([]string))
+		ruleAdded = e.addPolicy("p", name, params[0].([]string))
 	} else {
 		policy := make([]string, 0)
 		for _, param := range params {
 			policy = append(policy, param.(string))
 		}
 
-		ruleAdded = e.addPolicy("p", "p", policy)
+		ruleAdded = e.addPolicy("p", name, policy)
 	}
 
 	return ruleAdded
@@ -93,31 +145,46 @@ func (e *Enforcer) AddPolicy(params ...interface{}) bool {
 
 // RemovePolicy removes an authorization rule from the current policy.
 func (e *Enforcer) RemovePolicy(params ...interface{}) bool {
+	return e.RemoveNamedPolicy("p", params...)
+}
+
+// RemoveFilteredPolicy removes an authorization rule from the current policy, field filters can be specified.
+func (e *Enforcer) RemoveFilteredPolicy(fieldIndex int, fieldValues ...string) bool {
+	return e.RemoveFilteredNamedPolicy("p", fieldIndex, fieldValues...)
+}
+
+// RemoveNamedPolicy removes an authorization rule from the current named policy.
+func (e *Enforcer) RemoveNamedPolicy(name string, params ...interface{}) bool {
 	ruleRemoved := false
 	if len(params) == 1 && reflect.TypeOf(params[0]).Kind() == reflect.Slice {
-		ruleRemoved = e.removePolicy("p", "p", params[0].([]string))
+		ruleRemoved = e.removePolicy("p", name, params[0].([]string))
 	} else {
 		policy := make([]string, 0)
 		for _, param := range params {
 			policy = append(policy, param.(string))
 		}
 
-		ruleRemoved = e.removePolicy("p", "p", policy)
+		ruleRemoved = e.removePolicy("p", name, policy)
 	}
 
 	return ruleRemoved
 }
 
-// RemoveFilteredPolicy removes an authorization rule from the current policy, field filters can be specified.
-func (e *Enforcer) RemoveFilteredPolicy(fieldIndex int, fieldValues ...string) bool {
-	ruleRemoved := e.removeFilteredPolicy("p", "p", fieldIndex, fieldValues...)
+// RemoveFilteredNamedPolicy removes an authorization rule from the current named policy, field filters can be specified.
+func (e *Enforcer) RemoveFilteredNamedPolicy(name string, fieldIndex int, fieldValues ...string) bool {
+	ruleRemoved := e.removeFilteredPolicy("p", name, fieldIndex, fieldValues...)
 	return ruleRemoved
 }
 
 // HasGroupingPolicy determines whether a role inheritance rule exists.
 func (e *Enforcer) HasGroupingPolicy(params ...interface{}) bool {
+	return e.HasNamedGroupingPolicy("g", params...)
+}
+
+// HasNamedGroupingPolicy determines whether a named role inheritance rule exists.
+func (e *Enforcer) HasNamedGroupingPolicy(name string, params ...interface{}) bool {
 	if len(params) == 1 && reflect.TypeOf(params[0]).Kind() == reflect.Slice {
-		return e.model.HasPolicy("g", "g", params[0].([]string))
+		return e.model.HasPolicy("g", name, params[0].([]string))
 	}
 
 	policy := make([]string, 0)
@@ -125,23 +192,30 @@ func (e *Enforcer) HasGroupingPolicy(params ...interface{}) bool {
 		policy = append(policy, param.(string))
 	}
 
-	return e.model.HasPolicy("g", "g", policy)
+	return e.model.HasPolicy("g", name, policy)
 }
 
 // AddGroupingPolicy adds a role inheritance rule to the current policy.
 // If the rule already exists, the function returns false and the rule will not be added.
 // Otherwise the function returns true by adding the new rule.
 func (e *Enforcer) AddGroupingPolicy(params ...interface{}) bool {
+	return e.AddNamedGroupingPolicy("g", params...)
+}
+
+// AddNamedGroupingPolicy adds a named role inheritance rule to the current policy.
+// If the rule already exists, the function returns false and the rule will not be added.
+// Otherwise the function returns true by adding the new rule.
+func (e *Enforcer) AddNamedGroupingPolicy(name string, params ...interface{}) bool {
 	ruleAdded := false
 	if len(params) == 1 && reflect.TypeOf(params[0]).Kind() == reflect.Slice {
-		ruleAdded = e.addPolicy("g", "g", params[0].([]string))
+		ruleAdded = e.addPolicy("g", name, params[0].([]string))
 	} else {
 		policy := make([]string, 0)
 		for _, param := range params {
 			policy = append(policy, param.(string))
 		}
 
-		ruleAdded = e.addPolicy("g", "g", policy)
+		ruleAdded = e.addPolicy("g", name, policy)
 	}
 
 	e.model.BuildRoleLinks(e.rmc)
@@ -150,25 +224,35 @@ func (e *Enforcer) AddGroupingPolicy(params ...interface{}) bool {
 
 // RemoveGroupingPolicy removes a role inheritance rule from the current policy.
 func (e *Enforcer) RemoveGroupingPolicy(params ...interface{}) bool {
+	return e.RemoveNamedGroupingPolicy("g", params...)
+}
+
+// RemoveFilteredGroupingPolicy removes a role inheritance rule from the current policy, field filters can be specified.
+func (e *Enforcer) RemoveFilteredGroupingPolicy(fieldIndex int, fieldValues ...string) bool {
+	return e.RemoveFilteredNamedGroupingPolicy("g", fieldIndex, fieldValues...)
+}
+
+// RemoveNamedGroupingPolicy removes a role inheritance rule from the current named policy.
+func (e *Enforcer) RemoveNamedGroupingPolicy(name string, params ...interface{}) bool {
 	ruleRemoved := false
 	if len(params) == 1 && reflect.TypeOf(params[0]).Kind() == reflect.Slice {
-		ruleRemoved = e.removePolicy("g", "g", params[0].([]string))
+		ruleRemoved = e.removePolicy("g", name, params[0].([]string))
 	} else {
 		policy := make([]string, 0)
 		for _, param := range params {
 			policy = append(policy, param.(string))
 		}
 
-		ruleRemoved = e.removePolicy("g", "g", policy)
+		ruleRemoved = e.removePolicy("g", name, policy)
 	}
 
 	e.model.BuildRoleLinks(e.rmc)
 	return ruleRemoved
 }
 
-// RemoveFilteredGroupingPolicy removes a role inheritance rule from the current policy, field filters can be specified.
-func (e *Enforcer) RemoveFilteredGroupingPolicy(fieldIndex int, fieldValues ...string) bool {
-	ruleRemoved := e.removeFilteredPolicy("g", "g", fieldIndex, fieldValues...)
+// RemoveFilteredNamedGroupingPolicy removes a role inheritance rule from the current named policy, field filters can be specified.
+func (e *Enforcer) RemoveFilteredNamedGroupingPolicy(name string, fieldIndex int, fieldValues ...string) bool {
+	ruleRemoved := e.removeFilteredPolicy("g", name, fieldIndex, fieldValues...)
 	e.model.BuildRoleLinks(e.rmc)
 	return ruleRemoved
 }


### PR DESCRIPTION
Expand the Management API to include functions allowing for multiple policy definitions to be managed concurrently, for example grouping policies "g" and "g2" in the case of RBAC with resource roles enabled. Preexisting functionality is unchanged.

The primary use case I'm interested in is support for resource roles, as in the example above, but this change will allow for more flexible usage of the API in general, to more closely mirror what is possible for static policies. My goal is to minimize disruption and fit into the existing API as cleanly as possible.

Example:
```golang
enforcer.AddGroupingPolicy("user", "admin")  // unchanged
enforcer.AddNamedGroupingPolicy("g2", "data1", "data_role") // new capability
```