### PR TITLE
Improve test coverage from 76% to 99%

### DIFF
--- a/enforcer_safe.go
+++ b/enforcer_safe.go
@@ -14,21 +14,16 @@
 
 package casbin
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+)
 
 // NewEnforcerSafe calls NewEnforcer in a safe way, returns error instead of causing panic.
 func NewEnforcerSafe(params ...interface{}) (e *Enforcer, err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			switch x := r.(type) {
-			case string:
-				err = errors.New(x)
-			case error:
-				err = x
-			default:
-				err = errors.New("Unknown panic")
-			}
-
+			err = errors.New(fmt.Sprintf("%v",r))
 			e = nil
 		}
 	}()
@@ -42,14 +37,7 @@ func NewEnforcerSafe(params ...interface{}) (e *Enforcer, err error) {
 func (e *Enforcer) LoadModelSafe() (err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			switch x := r.(type) {
-			case string:
-				err = errors.New(x)
-			case error:
-				err = x
-			default:
-				err = errors.New("Unknown panic")
-			}
+			err = errors.New(fmt.Sprintf("%v",r))
 		}
 	}()
 
@@ -62,20 +50,51 @@ func (e *Enforcer) LoadModelSafe() (err error) {
 func (e *Enforcer) EnforceSafe(rvals ...interface{}) (result bool, err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			switch x := r.(type) {
-			case string:
-				err = errors.New(x)
-			case error:
-				err = x
-			default:
-				err = errors.New("Unknown panic")
-			}
-
+			err = errors.New(fmt.Sprintf("%v",r))
 			result = false
 		}
 	}()
 
 	result = e.Enforce(rvals...)
+	err = nil
+	return
+}
+
+func (e *Enforcer) AddPolicySafe(params ...interface{}) (result bool, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = errors.New(fmt.Sprintf("%v",r))
+			result = false
+		}
+	}()
+
+	result = e.AddNamedPolicy("p", params...)
+	err = nil
+	return
+}
+
+func (e *Enforcer) RemovePolicySafe(params ...interface{}) (result bool, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = errors.New(fmt.Sprintf("%v",r))
+			result = false
+		}
+	}()
+
+	result = e.RemoveNamedPolicy("p", params...)
+	err = nil
+	return
+}
+
+func (e *Enforcer) RemoveFilteredPolicySafe(fieldIndex int, fieldValues ...string) (result bool, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = errors.New(fmt.Sprintf("%v",r))
+			result = false
+		}
+	}()
+
+	result = e.RemoveFilteredNamedPolicy("p", fieldIndex, fieldValues...)
 	err = nil
 	return
 }

--- a/error_test.go
+++ b/error_test.go
@@ -16,6 +16,7 @@ package casbin
 
 import (
 	"fmt"
+	"github.com/casbin/casbin/file-adapter"
 	"testing"
 )
 
@@ -29,10 +30,28 @@ func TestPathError(t *testing.T) {
 	}
 }
 
+func TestEnforcerParamError(t *testing.T) {
+	_, err := NewEnforcerSafe(1, 2, 3)
+	if err == nil {
+		t.Errorf("Should not be error here.")
+	} else {
+		fmt.Print("Test on error: ")
+		fmt.Print(err.Error())
+	}
+
+	_, err2 := NewEnforcerSafe(1, "2")
+	if err2 == nil {
+		t.Errorf("Should not be error here.")
+	} else {
+		fmt.Print("Test on error: ")
+		fmt.Print(err2.Error())
+	}
+}
+
 func TestModelError(t *testing.T) {
 	_, err := NewEnforcerSafe("examples/error/error_model.conf", "examples/error/error_policy.csv")
 	if err == nil {
-		t.Errorf("Should be error here.")
+		t.Errorf("Should not be an error here.")
 	} else {
 		fmt.Print("Test on error: ")
 		fmt.Print(err.Error())
@@ -83,5 +102,53 @@ func TestNoError(t *testing.T) {
 		t.Errorf("Should be no error here.")
 		fmt.Print("Unexpected error: ")
 		fmt.Print(err.Error())
+	}
+}
+
+func TestModelNoError(t *testing.T) {
+	e := NewEnforcer("examples/basic_model.conf", "examples/basic_policy.csv")
+
+	e.modelPath = "hope_this_path_wont_exist"
+	err := e.LoadModelSafe()
+
+	if err == nil {
+		t.Errorf("Should not be an error here.")
+	} else {
+		fmt.Print("Test on error: ")
+		fmt.Print(err.Error())
+	}
+}
+
+func TestMockAdapterErrors(t *testing.T) {
+	adapter := fileadapter.NewAdapterMock("examples/rbac_policy_with_domains.csv")
+	adapter.SetMockErr("mock error")
+
+	e, _ := NewEnforcerSafe("examples/rbac_model_with_domains.conf", adapter)
+
+	_, err := e.AddPolicySafe("admin", "domain3", "data1", "read")
+
+	if err == nil {
+		t.Errorf("Should be an error here.")
+	} else {
+		fmt.Print("Test on error: ")
+		fmt.Print(err.Error())
+	}
+
+	_, err2 := e.RemoveFilteredPolicySafe(1, "domain1", "data1")
+
+	if err2 == nil {
+		t.Errorf("Should be an error here.")
+	} else {
+		fmt.Print("Test on error: ")
+		fmt.Print(err2.Error())
+	}
+
+	_, err3 := e.RemovePolicySafe("admin", "domain2", "data2", "read")
+
+	if err3 == nil {
+		t.Errorf("Should be an error here.")
+	} else {
+		fmt.Print("Test on error: ")
+		fmt.Print(err3.Error())
 	}
 }

--- a/examples/keymatch_custom_model.conf
+++ b/examples/keymatch_custom_model.conf
@@ -1,0 +1,11 @@
+[request_definition]
+r = sub, obj, act
+
+[policy_definition]
+p = sub, obj, act
+
+[policy_effect]
+e = some(where (p.eft == allow))
+
+[matchers]
+m = r.sub == p.sub && keyMatchCustom(r.obj, p.obj) && regexMatch(r.act, p.act)

--- a/examples/priority_policy_indetermine.csv
+++ b/examples/priority_policy_indetermine.csv
@@ -1,0 +1,1 @@
+p, alice, data1, read, intdetermin

--- a/examples/rbac_model_with_not_deny.conf
+++ b/examples/rbac_model_with_not_deny.conf
@@ -1,0 +1,14 @@
+[request_definition]
+r = sub, obj, act
+
+[policy_definition]
+p = sub, obj, act, eft
+
+[role_definition]
+g = _, _
+
+[policy_effect]
+e = !some(where (p_eft == deny))
+
+[matchers]
+m = g(r.sub, p.sub) && r.obj == p.obj && r.act == p.act

--- a/file-adapter/adapter_mock.go
+++ b/file-adapter/adapter_mock.go
@@ -1,0 +1,93 @@
+// Copyright 2017 The casbin Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fileadapter
+
+import (
+	"bufio"
+	"errors"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/casbin/casbin/model"
+	"github.com/casbin/casbin/persist"
+)
+
+// AdapterMock is the file adapter for Casbin.
+// It can load policy from file or save policy to file.
+type AdapterMock struct {
+	filePath   string
+	errorValue string
+}
+
+// NewAdapterMock is the constructor for AdapterMock.
+func NewAdapterMock(filePath string) *AdapterMock {
+	a := AdapterMock{}
+	a.filePath = filePath
+	return &a
+}
+
+// LoadPolicy loads all policy rules from the storage.
+func (a *AdapterMock) LoadPolicy(model model.Model) error {
+	err := a.loadPolicyFile(model, persist.LoadPolicyLine)
+	return err
+}
+
+// SavePolicy saves all policy rules to the storage.
+func (a *AdapterMock) SavePolicy(model model.Model) error {
+	return nil
+}
+
+func (a *AdapterMock) loadPolicyFile(model model.Model, handler func(string, model.Model)) error {
+	f, _ := os.Open(a.filePath)
+	buf := bufio.NewReader(f)
+	for {
+		line, err := buf.ReadString('\n')
+		line = strings.TrimSpace(line)
+		handler(line, model)
+		if err != nil {
+			if err == io.EOF {
+				return nil
+			}
+		}
+	}
+}
+
+func (a *AdapterMock) SetMockErr(errorToSet string) {
+	a.errorValue = errorToSet
+}
+
+func (a *AdapterMock) GetMockErr() error {
+	var returnError error
+	if a.errorValue != "" {
+		returnError = errors.New(a.errorValue)
+	}
+	return returnError
+}
+
+// AddPolicy adds a policy rule to the storage.
+func (a *AdapterMock) AddPolicy(sec string, ptype string, rule []string) error {
+	return a.GetMockErr()
+}
+
+// RemovePolicy removes a policy rule from the storage.
+func (a *AdapterMock) RemovePolicy(sec string, ptype string, rule []string) error {
+	return a.GetMockErr()
+}
+
+// RemoveFilteredPolicy removes policy rules that match the filter from the storage.
+func (a *AdapterMock) RemoveFilteredPolicy(sec string, ptype string, fieldIndex int, fieldValues ...string) error {
+	return a.GetMockErr()
+}

--- a/management_api_test.go
+++ b/management_api_test.go
@@ -100,6 +100,16 @@ func testHasGroupingPolicy(t *testing.T, e *Enforcer, policy []string, res bool)
 	}
 }
 
+func testHasGroupingPolicyStringInput(t *testing.T, e *Enforcer, policy1 string, policy2 string, res bool) {
+	t.Helper()
+	myRes := e.HasGroupingPolicy(policy1, policy2)
+	log.Print("Has grouping policy ", policy1, policy2, ": ", myRes)
+
+	if res != myRes {
+		t.Error("Has grouping policy ", policy1, policy2, ": ", myRes, ", supposed to be ", res)
+	}
+}
+
 func TestGetPolicy(t *testing.T) {
 	e := NewEnforcer("examples/rbac_model.conf", "examples/rbac_policy.csv")
 
@@ -139,6 +149,9 @@ func TestGetPolicy(t *testing.T) {
 
 	testHasGroupingPolicy(t, e, []string{"alice", "data2_admin"}, true)
 	testHasGroupingPolicy(t, e, []string{"bob", "data2_admin"}, false)
+
+	testHasGroupingPolicyStringInput(t, e, "alice", "data2_admin", true)
+	testHasGroupingPolicyStringInput(t, e, "bob", "data2_admin", false)
 }
 
 func TestModifyPolicy(t *testing.T) {
@@ -155,6 +168,10 @@ func TestModifyPolicy(t *testing.T) {
 	e.RemovePolicy("alice", "data1", "read")
 	e.AddPolicy("eve", "data3", "read")
 	e.AddPolicy("eve", "data3", "read")
+
+	namedPolicy := []string{"eve", "data3", "read"}
+	e.RemoveNamedPolicy("p", namedPolicy)
+	e.AddNamedPolicy("p", namedPolicy)
 
 	testGetPolicy(t, e, [][]string{
 		{"data2_admin", "data2", "read"},
@@ -177,6 +194,12 @@ func TestModifyGroupingPolicy(t *testing.T) {
 	e.RemoveGroupingPolicy("alice", "data2_admin")
 	e.AddGroupingPolicy("bob", "data1_admin")
 	e.AddGroupingPolicy("eve", "data3_admin")
+
+	namedGroupingPolicy := []string{"alice", "data2_admin"}
+	testGetRoles(t, e, "alice", []string{})
+	e.AddNamedGroupingPolicy("g", namedGroupingPolicy)
+	testGetRoles(t, e, "alice", []string{"data2_admin"})
+	e.RemoveNamedGroupingPolicy("g", namedGroupingPolicy)
 
 	testGetRoles(t, e, "alice", []string{})
 	testGetRoles(t, e, "bob", []string{"data1_admin"})

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -1,0 +1,9 @@
+package model
+
+import (
+	"testing"
+)
+
+func TestModel(t *testing.T) {
+	//No tests yet
+}

--- a/persist/persist_test.go
+++ b/persist/persist_test.go
@@ -1,0 +1,9 @@
+package persist
+
+import (
+	"testing"
+)
+
+func TestPersist(t *testing.T) {
+	//No tests yet
+}


### PR DESCRIPTION
Hi Yang,

Here's a PR to improve your code coverage from 76% to 99% (I could probably get the last little bit with some refactoring). Not sure how Coveralls is calculating coverage - I'm using go test -coverprofile=coverage.out github.com/casbin/casbin)

I mostly tried to add new test cases but some functionality wasn't testable without minor code changes.
--Added safe methods for AddPolicySafe/RemovePolicySafe/RemoveFilteredPolicySafe
--Simplified the recover blocks for enforcer_safe (I saw that you got your code from Stack Overflow but that answer in my mind is overly complicated and untestable). I used the same approach I've seen in other projects like gin-gonic https://github.com/gin-gonic/gin/blob/master/recovery.go#L37.
--Added a mock file adapter

Also the sync enforcer is hard to test as written. So I replaced all the test cases to test sync instead of the regular one. If you want to test both you can either:
--Duplicate your test cases substantially
--Create a common interface and test that (I'm happy to do that) https://medium.com/agrea-technogies/mocking-dependencies-in-go-bb9739fef008