### PR TITLE
Adding tests and showing unexplained panic

### DIFF
--- a/enforcer_test.go
+++ b/enforcer_test.go
@@ -21,33 +21,6 @@ import (
 	"github.com/casbin/casbin/file-adapter"
 )
 
-func TestGetAndSetModel(t *testing.T) {
-	e := NewEnforcer("examples/basic_model.conf", "examples/basic_policy.csv")
-
-	model := e.GetModel()
-	e.SetModel(model)
-}
-
-func TestGetAndSetAdapter(t *testing.T) {
-	m := NewModel()
-	m.AddDef("r", "r", "sub, obj, act")
-	m.AddDef("p", "p", "sub, obj, act")
-	m.AddDef("e", "e", "some(where (p.eft == allow))")
-	m.AddDef("m", "m", "r.sub == p.sub && keyMatch(r.obj, p.obj) && regexMatch(r.act, p.act)")
-
-	a := fileadapter.NewAdapter("examples/keymatch_policy.csv")
-
-	e := NewEnforcer(m)
-
-	e.SetAdapter(a)
-	a2 := e.GetAdapter()
-	e.SetAdapter(a2)
-
-	e.LoadPolicy()
-
-	testEnforce(t, e, "alice", "/alice_data/resource1", "GET", true)
-}
-
 func TestKeyMatchModelInMemory(t *testing.T) {
 	m := NewModel()
 	m.AddDef("r", "r", "sub, obj, act")
@@ -369,4 +342,77 @@ func TestRoleLinks(t *testing.T) {
 	e.EnableAutoBuildRoleLinks(false)
 	e.BuildRoleLinks()
 	e.Enforce("user501", "data9", "read")
+}
+
+func TestGetAndSetModel(t *testing.T) {
+	e := NewEnforcer("examples/basic_model.conf", "examples/basic_policy.csv")
+	e2 := NewEnforcer("examples/basic_model_with_root.conf", "examples/basic_policy.csv")
+
+	testEnforce(t, e, "root", "data1", "read", false)
+
+	e.SetModel(e2.GetModel())
+
+	testEnforce(t, e, "root", "data1", "read", true)
+}
+
+func TestGetAndSetAdapterInMem(t *testing.T) {
+
+	e := NewEnforcer("examples/basic_model.conf", "examples/basic_policy.csv")
+	e2 := NewEnforcer("examples/basic_model.conf", "examples/basic_policy_inverse.csv")
+
+	testEnforce(t, e, "alice", "data1", "read", true)
+	testEnforce(t, e, "alice", "data1", "write", false)
+
+	a2 := e2.GetAdapter()
+	e.SetAdapter(a2)
+	e.LoadPolicy()
+
+	testEnforce(t, e, "alice", "data1", "read", false)
+	testEnforce(t, e, "alice", "data1", "write", true)
+}
+
+func TestSetAdapterFromFile(t *testing.T) {
+	e := NewEnforcer("examples/basic_model.conf")
+
+	testEnforce(t, e, "alice", "data1", "read", false)
+
+	a := fileadapter.NewAdapter("examples/basic_policy.csv")
+	e.SetAdapter(a)
+	e.LoadPolicy()
+
+	testEnforce(t, e, "alice", "data1", "read", true)
+}
+
+func TestInitEmpty(t *testing.T) {
+
+	e := NewEnforcer()
+
+	m := NewModel()
+	m.AddDef("r", "r", "sub, obj, act")
+	m.AddDef("p", "p", "sub, obj, act")
+	m.AddDef("e", "e", "some(where (p.eft == allow))")
+	m.AddDef("m", "m", "r.sub == p.sub && keyMatch(r.obj, p.obj) && regexMatch(r.act, p.act)")
+
+	a := fileadapter.NewAdapter("examples/keymatch_policy.csv")
+
+	e.SetModel(m)
+	e.SetAdapter(a)
+	e.LoadPolicy()
+
+	testEnforce(t, e, "alice", "/alice_data/resource1", "GET", true)
+}
+
+func TestInitEmptyTempForComparison(t *testing.T) {
+
+	m := NewModel()
+	m.AddDef("r", "r", "sub, obj, act")
+	m.AddDef("p", "p", "sub, obj, act")
+	m.AddDef("e", "e", "some(where (p.eft == allow))")
+	m.AddDef("m", "m", "r.sub == p.sub && keyMatch(r.obj, p.obj) && regexMatch(r.act, p.act)")
+
+	a := fileadapter.NewAdapter("examples/keymatch_policy.csv")
+
+	e := NewEnforcer(m, a)
+
+	testEnforce(t, e, "alice", "/alice_data/resource1", "GET", true)
 }

--- a/examples/basic_policy_inverse.csv
+++ b/examples/basic_policy_inverse.csv
@@ -1,0 +1,2 @@
+p, alice, data1, write
+p, bob, data2, read


### PR DESCRIPTION
I've been testing getters/setters and getting a panic. I'm specifically trying to test this line (test is expected to fail):
https://github.com/casbin/casbin/blob/master/enforcer.go#L93

You can see the issue by running this code. What's strange is that when I look at the `expression.Evaluate()` - the parameters being passed are the same:
https://github.com/casbin/casbin/blob/master/enforcer.go#L322

```go
fmt.Printf("%v\n",parameters)
result, err := expression.Evaluate(parameters)
//map[p_act:GET r_sub:alice r_obj:/alice_data/resource1 p_sub:alice r_act:GET p_obj:/alice_data/*]
```

```go
go test -test.v -test.run ^TestInitEmpty$
=== RUN   TestInitEmpty
2017/12/08 16:07:43 [Policy:]
2017/12/08 16:07:43 [p :  sub, obj, act :  [[alice /alice_data/* GET] [alice /alice_data/resource1 POST] [bob /alice_data/resource2 GET] [bob /bob_data/* POST] [cathy /cathy_data (GET)|(POST)]]]
map[r_sub:alice p_sub:alice r_obj:/alice_data/resource1 r_act:GET p_obj:/alice_data/* p_act:GET]
--- FAIL: TestInitEmpty (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x114c2ef]

goroutine 5 [running]:
testing.tRunner.func1(0xc4200aa0f0)
	/usr/local/Cellar/go/1.9.2/libexec/src/testing/testing.go:711 +0x2d2
panic(0x11a3720, 0x12cae00)
	/usr/local/Cellar/go/1.9.2/libexec/src/runtime/panic.go:491 +0x283
github.com/casbin/casbin.(*Enforcer).Enforce(0xc42007e190, 0xc420055ea8, 0x3, 0x3, 0xc420055ea0)
	/Users/dennch3/go/thingspace/go/src/github.com/casbin/casbin/enforcer.go:324 +0x71f
github.com/casbin/casbin.testEnforce(0xc4200aa0f0, 0xc42007e190, 0x11d2358, 0x5, 0x1191b60, 0x11f33c0, 0x11d1fe2, 0x3, 0x1073401)
	/Users/dennch3/go/thingspace/go/src/github.com/casbin/casbin/model_test.go:26 +0x144
github.com/casbin/casbin.TestInitEmpty(0xc4200aa0f0)
	/Users/dennch3/go/thingspace/go/src/github.com/casbin/casbin/enforcer_test.go:402 +0x267
testing.tRunner(0xc4200aa0f0, 0x11dd478)
	/usr/local/Cellar/go/1.9.2/libexec/src/testing/testing.go:746 +0xd0
created by testing.(*T).Run
	/usr/local/Cellar/go/1.9.2/libexec/src/testing/testing.go:789 +0x2de
exit status 2
FAIL	github.com/casbin/casbin	0.833s
```