### PR TITLE
Safe to check variable line after TrimSpace()

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -110,14 +110,14 @@ func (c *Config) parseBuffer(buf *bufio.Reader) (err error) {
 		line, _, err := buf.ReadLine()
 		if err == io.EOF {
 			break
-		} else if bytes.Equal(line, []byte{}) {
-			continue
 		} else if err != nil {
 			return err
 		}
 
 		line = bytes.TrimSpace(line)
 		switch {
+		case bytes.Equal(line, []byte{}):
+			continue
 		case bytes.HasPrefix(line, DEFAULT_COMMENT):
 			continue
 		case bytes.HasPrefix(line, DEFAULT_COMMENT_SEM):


### PR DESCRIPTION
```
const (
	DefaultRoleModelText = `[request_definition]
	r = sub, obj, act
	
	[policy_definition]
	p = sub, obj, act, eft
	
	[role_definition]
	g = _, _
	
	[policy_effect]
	e = priority(p.eft) || deny
	
	[matchers]
	m = g(r.sub, p.sub) && r.obj == p.obj && r.act == p.act`
)
casbin.NewModel(DefaultRoleModelText) // error
```