### PR TITLE
remove redundant parenthesis from type conversion exprs

### DIFF
--- a/model_test.go
+++ b/model_test.go
@@ -396,7 +396,7 @@ func CustomFunctionWrapper(args ...interface{}) (interface{}, error) {
 	key1 := args[0].(string)
 	key2 := args[1].(string)
 
-	return (bool)(CustomFunction(key1, key2)), nil
+	return bool(CustomFunction(key1, key2)), nil
 }
 
 func TestKeyMatchCustomModel(t *testing.T) {

--- a/util/builtin_operators.go
+++ b/util/builtin_operators.go
@@ -41,7 +41,7 @@ func KeyMatchFunc(args ...interface{}) (interface{}, error) {
 	name1 := args[0].(string)
 	name2 := args[1].(string)
 
-	return (bool)(KeyMatch(name1, name2)), nil
+	return bool(KeyMatch(name1, name2)), nil
 }
 
 // KeyMatch2 determines whether key1 matches the pattern of key2 (similar to RESTful path), key2 can contain a *.
@@ -66,7 +66,7 @@ func KeyMatch2Func(args ...interface{}) (interface{}, error) {
 	name1 := args[0].(string)
 	name2 := args[1].(string)
 
-	return (bool)(KeyMatch2(name1, name2)), nil
+	return bool(KeyMatch2(name1, name2)), nil
 }
 
 // KeyMatch3 determines whether key1 matches the pattern of key2 (similar to RESTful path), key2 can contain a *.
@@ -91,7 +91,7 @@ func KeyMatch3Func(args ...interface{}) (interface{}, error) {
 	name1 := args[0].(string)
 	name2 := args[1].(string)
 
-	return (bool)(KeyMatch3(name1, name2)), nil
+	return bool(KeyMatch3(name1, name2)), nil
 }
 
 // RegexMatch determines whether key1 matches the pattern of key2 in regular expression.
@@ -108,7 +108,7 @@ func RegexMatchFunc(args ...interface{}) (interface{}, error) {
 	name1 := args[0].(string)
 	name2 := args[1].(string)
 
-	return (bool)(RegexMatch(name1, name2)), nil
+	return bool(RegexMatch(name1, name2)), nil
 }
 
 // IPMatch determines whether IP address ip1 matches the pattern of IP address ip2, ip2 can be an IP address or a CIDR pattern.
@@ -137,7 +137,7 @@ func IPMatchFunc(args ...interface{}) (interface{}, error) {
 	ip1 := args[0].(string)
 	ip2 := args[1].(string)
 
-	return (bool)(IPMatch(ip1, ip2)), nil
+	return bool(IPMatch(ip1, ip2)), nil
 }
 
 // GenerateGFunction is the factory method of the g(_, _) function.


### PR DESCRIPTION
(T)(v) is identical to T(v) when T is not a pointer type.

Found using https://go-critic.github.io/overview#typeUnparen-ref