### PR TITLE
Don't swallow errors

### DIFF
--- a/enforcer.go
+++ b/enforcer.go
@@ -312,7 +312,10 @@ func (e *Enforcer) Enforce(rvals ...interface{}) bool {
 	}
 
 	expString := e.model["m"]["m"].Value
-	expression, _ := govaluate.NewEvaluableExpressionWithFunctions(expString, functions)
+	expression, err := govaluate.NewEvaluableExpressionWithFunctions(expString, functions)
+	if err != nil {
+		panic(err)
+	}
 
 	var policyEffects []effect.Effect
 	var matcherResults []float64


### PR DESCRIPTION
The library as a general rule seems to follow the approach of throwing a panic in an unrecoverable situation.  This seems reasonable, but I found a spot where an error was being swallowed, which required me to clone the code, pull it into my code, and debug to find the problem.  It would have been much more clear if this error wasn't being swallowed.

This is the stacktrace without this PR:

```
runtime error: invalid memory address or nil pointer dereference
/usr/local/Cellar/go/1.11.1/libexec/src/runtime/panic.go:513 (0x102bd58)
	gopanic: reflectcall(nil, unsafe.Pointer(d.fn), deferArgs(d), uint32(d.siz), uint32(d.siz))
/usr/local/Cellar/go/1.11.1/libexec/src/runtime/panic.go:82 (0x102aead)
	panicmem: panic(memoryError)
/usr/local/Cellar/go/1.11.1/libexec/src/runtime/signal_unix.go:390 (0x1041221)
	sigpanic: panicmem()
/Users/davisford/git/authztest/vendor/github.com/casbin/casbin/enforcer.go:333 (0x1179659)
	(*Enforcer).Enforce: result, err := expression.Evaluate(parameters)
```

Which isn't very useful.  This is the stacktrace with the new panic when Govaluate returns an error:

```
Cannot transition token types from CLAUSE_CLOSE [41] to FUNCTION [0x11699c0]
/usr/local/Cellar/go/1.11.1/libexec/src/runtime/panic.go:513 (0x102bd58)
	gopanic: reflectcall(nil, unsafe.Pointer(d.fn), deferArgs(d), uint32(d.siz), uint32(d.siz))
/Users/davisford/git/authztest/vendor/github.com/casbin/casbin/enforcer.go:315 (0x117a878)
	(*Enforcer).Enforce: panic(err)
```

This tells me there was something wrong with my model.  Namely, I was missing a logical operator `&&`

```
[matchers]
m = g(r.sub, p.sub) && g2(r.obj, p.obj) \ 
  keyMatch(r.obj, p.obj) && \
  (r.act == p.act || p.act == "*")
```

I think the panic here is appropriate b/c it means my model is broken, thus everything is broken until it gets resolved.