### PR TITLE
[enhancement/#96] Skip filtered policy init

### DIFF
--- a/enforcer.go
+++ b/enforcer.go
@@ -121,7 +121,9 @@ func (e *Enforcer) InitWithModelAndAdapter(m model.Model, adapter persist.Adapte
 
 	e.initialize()
 
-	if e.adapter != nil {
+	// Do not initialize the full policy when using a filtered adapter
+	_, filtered := e.adapter.(persist.FilteredAdapter)
+	if e.adapter != nil && !filtered {
 		// error intentionally ignored
 		e.LoadPolicy()
 	}

--- a/filter_test.go
+++ b/filter_test.go
@@ -20,11 +20,24 @@ import (
 	"github.com/casbin/casbin/persist/file-adapter"
 )
 
+func TestInitFilteredAdapter(t *testing.T) {
+	e := NewEnforcer()
+
+	adapter := fileadapter.NewFilteredAdapter("examples/rbac_with_domains_policy.csv")
+	e.InitWithAdapter("examples/rbac_with_domains_model.conf", adapter)
+
+	// policy should not be loaded yet
+	testHasPolicy(t, e, []string{"admin", "domain1", "data1", "read"}, false)
+}
+
 func TestLoadFilteredPolicy(t *testing.T) {
 	e := NewEnforcer()
 
 	adapter := fileadapter.NewFilteredAdapter("examples/rbac_with_domains_policy.csv")
 	e.InitWithAdapter("examples/rbac_with_domains_model.conf", adapter)
+	if err := e.LoadPolicy(); err != nil {
+		t.Errorf("unexpected error in LoadPolicy: %v", err)
+	}
 
 	// validate initial conditions
 	testHasPolicy(t, e, []string{"admin", "domain1", "data1", "read"}, true)


### PR DESCRIPTION
Do not load the full policy when initializing a filtered adapter.

Closes #96 