### PR TITLE
Add more explicit panic log when the defined policy rule is invalid

### DIFF
--- a/enforcer.go
+++ b/enforcer.go
@@ -324,10 +324,24 @@ func (e *Enforcer) Enforce(rvals ...interface{}) bool {
 	if policyLen := len(e.model["p"]["p"].Policy); policyLen != 0 {
 		policyEffects = make([]effect.Effect, policyLen)
 		matcherResults = make([]float64, policyLen)
-
+		if len(e.model["r"]["r"].Tokens) != len(rvals) {
+			panic(
+				fmt.Sprintf(
+					"Invalid Request Definition size: expected %d got %d rvals: %v",
+					len(e.model["r"]["r"].Tokens),
+					len(rvals),
+					rvals))
+		}
 		for i, pvals := range e.model["p"]["p"].Policy {
 			// log.LogPrint("Policy Rule: ", pvals)
-
+			if len(e.model["p"]["p"].Tokens) != len(pvals) {
+				panic(
+					fmt.Sprintf(
+						"Invalid Policy Rule size: expected %d got %d pvals: %v",
+						len(e.model["p"]["p"].Tokens),
+						len(pvals),
+						pvals))
+			}
 			parameters := make(map[string]interface{}, 8)
 			for j, token := range e.model["r"]["r"].Tokens {
 				parameters[token] = rvals[j]


### PR DESCRIPTION
```
runtime error: index out of range
/usr/local/go/src/runtime/panic.go:513 (0x42a5a8)
/usr/local/go/src/runtime/panic.go:44 (0x4293e9)
/go/pkg/mod/github.com/casbin/casbin@v1.8.0/enforcer.go:339 (0x9d153a)
/go/pkg/mod/github.com/casbin/casbin@v1.8.0/enforcer_synced.go:106 (0x9d24e3)
```
We had this error in production. 
The code gives more info on the error when it occurs
