### PR TITLE
Performance improvement: avoid copying govaluate parameters unnecessarily

### DIFF
--- a/enforcer.go
+++ b/enforcer.go
@@ -23,9 +23,9 @@ import (
 	"github.com/casbin/casbin/log"
 	"github.com/casbin/casbin/model"
 	"github.com/casbin/casbin/persist"
-	"github.com/casbin/casbin/persist/file-adapter"
+	fileadapter "github.com/casbin/casbin/persist/file-adapter"
 	"github.com/casbin/casbin/rbac"
-	"github.com/casbin/casbin/rbac/default-role-manager"
+	defaultrolemanager "github.com/casbin/casbin/rbac/default-role-manager"
 	"github.com/casbin/casbin/util"
 )
 
@@ -319,6 +319,22 @@ func (e *Enforcer) Enforce(rvals ...interface{}) bool {
 		panic(err)
 	}
 
+	rTokens := make(map[string]int, len(e.model["r"]["r"].Tokens))
+	for i, token := range e.model["r"]["r"].Tokens {
+		rTokens[token] = i
+	}
+	pTokens := make(map[string]int, len(e.model["p"]["p"].Tokens))
+	for i, token := range e.model["p"]["p"].Tokens {
+		pTokens[token] = i
+	}
+
+	parameters := enforceParameters{
+		rTokens: rTokens,
+		rVals:   rvals,
+
+		pTokens: pTokens,
+	}
+
 	var policyEffects []effect.Effect
 	var matcherResults []float64
 	if policyLen := len(e.model["p"]["p"].Policy); policyLen != 0 {
@@ -342,15 +358,10 @@ func (e *Enforcer) Enforce(rvals ...interface{}) bool {
 						len(pvals),
 						pvals))
 			}
-			parameters := make(map[string]interface{}, 8)
-			for j, token := range e.model["r"]["r"].Tokens {
-				parameters[token] = rvals[j]
-			}
-			for j, token := range e.model["p"]["p"].Tokens {
-				parameters[token] = pvals[j]
-			}
 
-			result, err := expression.Evaluate(parameters)
+			parameters.pVals = pvals
+
+			result, err := expression.Eval(parameters)
 			// log.LogPrint("Result: ", result)
 
 			if err != nil {
@@ -375,7 +386,8 @@ func (e *Enforcer) Enforce(rvals ...interface{}) bool {
 				panic(errors.New("matcher result should be bool, int or float"))
 			}
 
-			if eft, ok := parameters["p_eft"]; ok {
+			if j, ok := parameters.pTokens["p_eft"]; ok {
+				eft := parameters.pVals[j]
 				if eft == "allow" {
 					policyEffects[i] = effect.Allow
 				} else if eft == "deny" {
@@ -396,15 +408,9 @@ func (e *Enforcer) Enforce(rvals ...interface{}) bool {
 		policyEffects = make([]effect.Effect, 1)
 		matcherResults = make([]float64, 1)
 
-		parameters := make(map[string]interface{}, 8)
-		for j, token := range e.model["r"]["r"].Tokens {
-			parameters[token] = rvals[j]
-		}
-		for _, token := range e.model["p"]["p"].Tokens {
-			parameters[token] = ""
-		}
+		parameters.pVals = make([]string, len(parameters.pTokens))
 
-		result, err := expression.Evaluate(parameters)
+		result, err := expression.Eval(parameters)
 		// log.LogPrint("Result: ", result)
 
 		if err != nil {
@@ -441,4 +447,37 @@ func (e *Enforcer) Enforce(rvals ...interface{}) bool {
 	}
 
 	return result
+}
+
+// assumes bounds have already been checked
+type enforceParameters struct {
+	rTokens map[string]int
+	rVals   []interface{}
+
+	pTokens map[string]int
+	pVals   []string
+}
+
+// implements govaluate.Parameters
+func (p enforceParameters) Get(name string) (interface{}, error) {
+	if name == "" {
+		return nil, nil
+	}
+
+	switch name[0] {
+	case 'p':
+		i, ok := p.pTokens[name]
+		if !ok {
+			return nil, errors.New("No parameter '" + name + "' found.")
+		}
+		return p.pVals[i], nil
+	case 'r':
+		i, ok := p.rTokens[name]
+		if !ok {
+			return nil, errors.New("No parameter '" + name + "' found.")
+		}
+		return p.rVals[i], nil
+	default:
+		return nil, errors.New("No parameter '" + name + "' found.")
+	}
 }


### PR DESCRIPTION
While doing some profiling of our casbin enforcement model I discovered a significant time spent in copying memory around to create the govaluate parameter map.

Excerpt of profile in `Enforce` function:

```
      10ms       20ms    337:                   if len(e.model["p"]["p"].Tokens) != len(pvals) {
         .          .    338:                           panic(
         .          .    339:                                   fmt.Sprintf(
         .          .    340:                                           "Invalid Policy Rule size: expected %d got %d pvals: %v",
         .          .    341:                                           len(e.model["p"]["p"].Tokens),
         .          .    342:                                           len(pvals),
         .          .    343:                                           pvals))
         .          .    344:                   }
         .       80ms    345:                   parameters := make(map[string]interface{}, 8)
         .       30ms    346:                   for j, token := range e.model["r"]["r"].Tokens {
      30ms      270ms    347:                           parameters[token] = rvals[j]
         .          .    348:                   }
      10ms       50ms    349:                   for j, token := range e.model["p"]["p"].Tokens {
         .      300ms    350:                           parameters[token] = pvals[j]
         .          .    351:                   }
         .          .    352:
         .      1.19s    353:                   result, err := expression.Evaluate(parameters)
```

To avoid some of the copying, I introduced a struct that satisfies `govaluate.Parameters` that allows us to simply copy slice headers rather than the values themselves during evaluation.

Benchmarks on my machine (I couldn't run the `*Large` benchmarks locally so I left them out):

Before:

```
BenchmarkCachedRaw-4                            50000000                25.6 ns/op             0 B/op          0 allocs/op
BenchmarkCachedBasicModel-4                      5000000               278 ns/op             104 B/op          4 allocs/op
BenchmarkCachedRBACModel-4                       5000000               273 ns/op             104 B/op          4 allocs/op
BenchmarkCachedRBACModelSmall-4                  5000000               287 ns/op             112 B/op          4 allocs/op
BenchmarkCachedRBACModelMedium-4                 3000000               387 ns/op             128 B/op          4 allocs/op
BenchmarkCachedRBACModelWithResourceRoles-4      5000000               276 ns/op             104 B/op          4 allocs/op
BenchmarkCachedRBACModelWithDomains-4            5000000               347 ns/op             152 B/op          5 allocs/op
BenchmarkCachedABACModel-4                        300000              4343 ns/op            1752 B/op         40 allocs/op
BenchmarkCachedKeyMatchModel-4                   5000000               283 ns/op             136 B/op          4 allocs/op
BenchmarkCachedRBACModelWithDeny-4               5000000               273 ns/op             104 B/op          4 allocs/op
BenchmarkCachedPriorityModel-4                   5000000               273 ns/op             104 B/op          4 allocs/op
BenchmarkCachedRBACModelMediumParallel-4         5000000               254 ns/op             128 B/op          4 allocs/op
BenchmarkRaw-4                                  50000000                25.3 ns/op             0 B/op          0 allocs/op
BenchmarkBasicModel-4                             200000             10167 ns/op            4408 B/op         90 allocs/op
BenchmarkRBACModel-4                              100000             14216 ns/op            5856 B/op        121 allocs/op
BenchmarkRBACModelSmall-4                          10000            124930 ns/op           58400 B/op       1085 allocs/op
BenchmarkRBACModelMedium-4                          1000           1606822 ns/op          548192 B/op      10085 allocs/op
BenchmarkRBACModelWithResourceRoles-4             100000             14779 ns/op            6528 B/op        126 allocs/op
BenchmarkRBACModelWithDomains-4                   100000             21758 ns/op            9000 B/op        181 allocs/op
BenchmarkABACModel-4                              300000              4266 ns/op            1744 B/op         39 allocs/op
BenchmarkKeyMatchModel-4                          100000             19983 ns/op           10333 B/op        164 allocs/op
BenchmarkRBACModelWithDeny-4                      100000             15567 ns/op            6432 B/op        134 allocs/op
BenchmarkPriorityModel-4                          200000             10421 ns/op            4416 B/op         94 allocs/op
```

After:

```
BenchmarkCachedRaw-4                            50000000                25.2 ns/op             0 B/op          0 allocs/op
BenchmarkCachedBasicModel-4                      5000000               274 ns/op             104 B/op          4 allocs/op
BenchmarkCachedRBACModel-4                       5000000               277 ns/op             104 B/op          4 allocs/op
BenchmarkCachedRBACModelSmall-4                  5000000               305 ns/op             112 B/op          4 allocs/op
BenchmarkCachedRBACModelMedium-4                 5000000               384 ns/op             128 B/op          4 allocs/op
BenchmarkCachedRBACModelWithResourceRoles-4      5000000               274 ns/op             104 B/op          4 allocs/op
BenchmarkCachedRBACModelWithDomains-4            5000000               333 ns/op             152 B/op          5 allocs/op
BenchmarkCachedABACModel-4                        300000              4825 ns/op            2040 B/op         44 allocs/op
BenchmarkCachedKeyMatchModel-4                   5000000               289 ns/op             136 B/op          4 allocs/op
BenchmarkCachedRBACModelWithDeny-4               5000000               277 ns/op             104 B/op          4 allocs/op
BenchmarkCachedPriorityModel-4                   5000000               274 ns/op             104 B/op          4 allocs/op
BenchmarkCachedRBACModelMediumParallel-4         5000000               253 ns/op             128 B/op          4 allocs/op
BenchmarkRaw-4                                  50000000                25.4 ns/op             0 B/op          0 allocs/op
BenchmarkBasicModel-4                             200000              9992 ns/op            4344 B/op         90 allocs/op
BenchmarkRBACModel-4                              100000             13518 ns/op            5232 B/op        118 allocs/op
BenchmarkRBACModelSmall-4                          20000             85102 ns/op           28528 B/op        790 allocs/op
BenchmarkRBACModelMedium-4                          2000            919692 ns/op          244720 B/op       7090 allocs/op
BenchmarkRBACModelWithResourceRoles-4             100000             14229 ns/op            6192 B/op        125 allocs/op
BenchmarkRBACModelWithDomains-4                   100000             20560 ns/op            8360 B/op        177 allocs/op
BenchmarkABACModel-4                              300000              5215 ns/op            2032 B/op         43 allocs/op
BenchmarkKeyMatchModel-4                          100000             18560 ns/op            9381 B/op        157 allocs/op
BenchmarkRBACModelWithDeny-4                      100000             14000 ns/op            5424 B/op        123 allocs/op
BenchmarkPriorityModel-4                          200000             10672 ns/op            4640 B/op         96 allocs/op
```

As you can note, there are substantial differences in execution time and allocations for the Medium sized models. I expect that the Large ones would show even more difference as currently the parameter values are copied for each policy statement.