### PR TITLE
Improvement/stop using NewModel constructor

### DIFF
--- a/enforcer.go
+++ b/enforcer.go
@@ -106,7 +106,11 @@ func (e *Enforcer) InitWithFile(modelPath string, policyPath string) {
 // InitWithAdapter initializes an enforcer with a database adapter.
 func (e *Enforcer) InitWithAdapter(modelPath string, adapter persist.Adapter) {
 	m := make(model.Model)
-	m.LoadModel(modelPath)
+	if modelPath == ""{
+		m.LoadModelFromText(modelPath)
+	}else{
+		m.LoadModel(modelPath)
+	}
 	e.InitWithModelAndAdapter(m, adapter)
 	e.modelPath = modelPath
 }

--- a/enforcer.go
+++ b/enforcer.go
@@ -105,9 +105,9 @@ func (e *Enforcer) InitWithFile(modelPath string, policyPath string) {
 
 // InitWithAdapter initializes an enforcer with a database adapter.
 func (e *Enforcer) InitWithAdapter(modelPath string, adapter persist.Adapter) {
-	m := NewModel(modelPath, "")
+	m := make(model.Model)
+	m.LoadModel(modelPath)
 	e.InitWithModelAndAdapter(m, adapter)
-
 	e.modelPath = modelPath
 }
 
@@ -140,6 +140,7 @@ func (e *Enforcer) initialize() {
 }
 
 // NewModel creates a model.
+// todo object constructors should live alongside their type declaration and should never panic
 func NewModel(text ...string) model.Model {
 	m := make(model.Model)
 
@@ -159,7 +160,7 @@ func NewModel(text ...string) model.Model {
 // LoadModel reloads the model from the model CONF file.
 // Because the policy is attached to a model, so the policy is invalidated and needs to be reloaded by calling LoadPolicy().
 func (e *Enforcer) LoadModel() {
-	e.model = NewModel()
+	e.model = make(model.Model)
 	e.model.LoadModel(e.modelPath)
 	e.model.PrintModel()
 	e.fm = model.LoadFunctionMap()

--- a/enforcer_test.go
+++ b/enforcer_test.go
@@ -15,13 +15,14 @@
 package casbin
 
 import (
+	"github.com/casbin/casbin/model"
 	"testing"
 
 	"github.com/casbin/casbin/persist/file-adapter"
 )
 
 func TestKeyMatchModelInMemory(t *testing.T) {
-	m := NewModel()
+	m := make(model.Model)
 	m.AddDef("r", "r", "sub, obj, act")
 	m.AddDef("p", "p", "sub, obj, act")
 	m.AddDef("e", "e", "some(where (p.eft == allow))")
@@ -80,7 +81,7 @@ func TestKeyMatchModelInMemory(t *testing.T) {
 }
 
 func TestKeyMatchModelInMemoryDeny(t *testing.T) {
-	m := NewModel()
+	m := make(model.Model)
 	m.AddDef("r", "r", "sub, obj, act")
 	m.AddDef("p", "p", "sub, obj, act")
 	m.AddDef("e", "e", "!some(where (p.eft == deny))")
@@ -94,7 +95,7 @@ func TestKeyMatchModelInMemoryDeny(t *testing.T) {
 }
 
 func TestRBACModelInMemoryIndeterminate(t *testing.T) {
-	m := NewModel()
+	m := make(model.Model)
 	m.AddDef("r", "r", "sub, obj, act")
 	m.AddDef("p", "p", "sub, obj, act")
 	m.AddDef("g", "g", "_, _")
@@ -109,7 +110,7 @@ func TestRBACModelInMemoryIndeterminate(t *testing.T) {
 }
 
 func TestRBACModelInMemory(t *testing.T) {
-	m := NewModel()
+	m := make(model.Model)
 	m.AddDef("r", "r", "sub, obj, act")
 	m.AddDef("p", "p", "sub, obj, act")
 	m.AddDef("g", "g", "_, _")
@@ -152,10 +153,8 @@ e = some(where (p.eft == allow))
 [matchers]
 m = g(r.sub, p.sub) && r.obj == p.obj && r.act == p.act
 `
-	m := NewModel(text)
-	// The above is the same as:
-	// m := NewModel()
-	// m.LoadModelFromText(text)
+	m := make(model.Model)
+	m.LoadModelFromText(text)
 
 	e := NewEnforcer(m)
 
@@ -176,7 +175,7 @@ m = g(r.sub, p.sub) && r.obj == p.obj && r.act == p.act
 }
 
 func TestNotUsedRBACModelInMemory(t *testing.T) {
-	m := NewModel()
+	m := make(model.Model)
 	m.AddDef("r", "r", "sub, obj, act")
 	m.AddDef("p", "p", "sub, obj, act")
 	m.AddDef("g", "g", "_, _")
@@ -379,7 +378,7 @@ func TestSetAdapterFromFile(t *testing.T) {
 func TestInitEmpty(t *testing.T) {
 	e := NewEnforcer()
 
-	m := NewModel()
+	m := make(model.Model)
 	m.AddDef("r", "r", "sub, obj, act")
 	m.AddDef("p", "p", "sub, obj, act")
 	m.AddDef("e", "e", "some(where (p.eft == allow))")


### PR DESCRIPTION
The misplaced and strange NewModel constructor (it panics and is only ever used to differentiate between a filepath and a text) in enforcer can be bypassed entirely by using the safer model load functions dependent on whether it's from a path or a string. 

Since it's public the function remains but the logic therein is weird. 