### PR TITLE
Test for a logger and use string.Builder

### DIFF
--- a/enforcer.go
+++ b/enforcer.go
@@ -17,6 +17,7 @@ package casbin
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/Knetic/govaluate"
 	"github.com/casbin/casbin/v2/effect"
@@ -456,16 +457,17 @@ func (e *Enforcer) Enforce(rvals ...interface{}) (bool, error) {
 
 	// Log request.
 	if log.GetLogger().IsEnabled() {
-		reqStr := "Request: "
+		var reqStr strings.Builder
+		reqStr.WriteString("Request: ")
 		for i, rval := range rvals {
 			if i != len(rvals)-1 {
-				reqStr += fmt.Sprintf("%v, ", rval)
+				reqStr.WriteString(fmt.Sprintf("%v, ", rval))
 			} else {
-				reqStr += fmt.Sprintf("%v", rval)
+				reqStr.WriteString(fmt.Sprintf("%v", rval))
 			}
 		}
-		reqStr += fmt.Sprintf(" ---> %t", result)
-		log.LogPrint(reqStr)
+		reqStr.WriteString(fmt.Sprintf(" ---> %t", result))
+		log.LogPrint(reqStr.String())
 	}
 
 	return result, nil

--- a/enforcer_cached.go
+++ b/enforcer_cached.go
@@ -15,6 +15,7 @@
 package casbin
 
 import (
+	"strings"
 	"sync"
 )
 
@@ -53,16 +54,17 @@ func (e *CachedEnforcer) Enforce(rvals ...interface{}) (bool, error) {
 		return e.Enforcer.Enforce(rvals...)
 	}
 
-	key := ""
+	var key strings.Builder
 	for _, rval := range rvals {
 		if val, ok := rval.(string); ok {
-			key += val + "$$"
+			key.WriteString(val)
+			key.WriteString("$$")
 		} else {
 			return e.Enforcer.Enforce(rvals...)
 		}
 	}
 
-	if res, ok := e.getCachedResult(key); ok {
+	if res, ok := e.getCachedResult(key.String()); ok {
 		return res, nil
 	} else {
 		res, err := e.Enforcer.Enforce(rvals...)
@@ -70,7 +72,7 @@ func (e *CachedEnforcer) Enforce(rvals ...interface{}) (bool, error) {
 			return false, err
 		}
 
-		e.setCachedResult(key, res)
+		e.setCachedResult(key.String(), res)
 		return res, nil
 	}
 }


### PR DESCRIPTION
This code shows a big performance issue when inserting many policies in
a row. This is because it builds a string to log without checking for a
logger (thus can build a string without using it).
Also concatening string in a loop cause a lot a memory allocation that
has to be handled by the garbage collector, which is the real
performance hit.

Using a string.Builder avoid this issue. Also check if the logger is
enabled before doing anything.

Change-Id: Ibb63237d6065e1d1a77bb290a493bf8715b150e3
Signed-off-by: Loïc Collignon <loic.collignon@iot.bzh>