### PR TITLE
add missing methods in management_api to SyncedEnforcer

### DIFF
--- a/enforcer_synced.go
+++ b/enforcer_synced.go
@@ -117,11 +117,25 @@ func (e *SyncedEnforcer) GetAllSubjects() []string {
 	return e.Enforcer.GetAllSubjects()
 }
 
+// GetAllNamedSubjects gets the list of subjects that show up in the current named policy.
+func (e *SyncedEnforcer) GetAllNamedSubjects(ptype string) []string {
+	e.m.RLock()
+	defer e.m.RUnlock()
+	return e.Enforcer.GetAllNamedSubjects(ptype)
+}
+
 // GetAllObjects gets the list of objects that show up in the current policy.
 func (e *SyncedEnforcer) GetAllObjects() []string {
 	e.m.RLock()
 	defer e.m.RUnlock()
 	return e.Enforcer.GetAllObjects()
+}
+
+// GetAllNamedObjects gets the list of objects that show up in the current named policy.
+func (e *SyncedEnforcer) GetAllNamedObjects(ptype string) []string {
+	e.m.RLock()
+	defer e.m.RUnlock()
+	return e.Enforcer.GetAllNamedObjects(ptype)
 }
 
 // GetAllActions gets the list of actions that show up in the current policy.
@@ -131,11 +145,25 @@ func (e *SyncedEnforcer) GetAllActions() []string {
 	return e.Enforcer.GetAllActions()
 }
 
+// GetAllNamedActions gets the list of actions that show up in the current named policy.
+func (e *SyncedEnforcer) GetAllNamedActions(ptype string) []string {
+	e.m.RLock()
+	defer e.m.RUnlock()
+	return e.Enforcer.GetAllNamedActions(ptype)
+}
+
 // GetAllRoles gets the list of roles that show up in the current policy.
 func (e *SyncedEnforcer) GetAllRoles() []string {
 	e.m.RLock()
 	defer e.m.RUnlock()
 	return e.Enforcer.GetAllRoles()
+}
+
+// GetAllNamedRoles gets the list of roles that show up in the current named policy.
+func (e *SyncedEnforcer) GetAllNamedRoles(ptype string) []string {
+	e.m.RLock()
+	defer e.m.RUnlock()
+	return e.Enforcer.GetAllNamedRoles(ptype)
 }
 
 // GetPolicy gets all the authorization rules in the policy.
@@ -152,6 +180,20 @@ func (e *SyncedEnforcer) GetFilteredPolicy(fieldIndex int, fieldValues ...string
 	return e.Enforcer.GetFilteredPolicy(fieldIndex, fieldValues...)
 }
 
+// GetNamedPolicy gets all the authorization rules in the named policy.
+func (e *SyncedEnforcer) GetNamedPolicy(ptype string) [][]string {
+	e.m.RLock()
+	defer e.m.RUnlock()
+	return e.Enforcer.GetNamedPolicy(ptype)
+}
+
+// GetFilteredNamedPolicy gets all the authorization rules in the named policy, field filters can be specified.
+func (e *SyncedEnforcer) GetFilteredNamedPolicy(ptype string, fieldIndex int, fieldValues ...string) [][]string {
+	e.m.RLock()
+	defer e.m.RUnlock()
+	return e.Enforcer.GetFilteredNamedPolicy(ptype, fieldIndex, fieldValues...)
+}
+
 // GetGroupingPolicy gets all the role inheritance rules in the policy.
 func (e *SyncedEnforcer) GetGroupingPolicy() [][]string {
 	e.m.RLock()
@@ -166,11 +208,32 @@ func (e *SyncedEnforcer) GetFilteredGroupingPolicy(fieldIndex int, fieldValues .
 	return e.Enforcer.GetFilteredGroupingPolicy(fieldIndex, fieldValues...)
 }
 
+// GetNamedGroupingPolicy gets all the role inheritance rules in the policy.
+func (e *SyncedEnforcer) GetNamedGroupingPolicy(ptype string) [][]string {
+	e.m.RLock()
+	defer e.m.RUnlock()
+	return e.Enforcer.GetNamedGroupingPolicy(ptype)
+}
+
+// GetFilteredNamedGroupingPolicy gets all the role inheritance rules in the policy, field filters can be specified.
+func (e *SyncedEnforcer) GetFilteredNamedGroupingPolicy(ptype string, fieldIndex int, fieldValues ...string) [][]string {
+	e.m.RLock()
+	defer e.m.RUnlock()
+	return e.Enforcer.GetFilteredNamedGroupingPolicy(ptype, fieldIndex, fieldValues...)
+}
+
 // HasPolicy determines whether an authorization rule exists.
 func (e *SyncedEnforcer) HasPolicy(params ...interface{}) bool {
 	e.m.RLock()
 	defer e.m.RUnlock()
 	return e.Enforcer.HasPolicy(params...)
+}
+
+// HasNamedPolicy determines whether a named authorization rule exists.
+func (e *SyncedEnforcer) HasNamedPolicy(ptype string, params ...interface{}) bool {
+	e.m.RLock()
+	defer e.m.RUnlock()
+	return e.Enforcer.HasNamedPolicy(ptype, params...)
 }
 
 // AddPolicy adds an authorization rule to the current policy.
@@ -180,6 +243,15 @@ func (e *SyncedEnforcer) AddPolicy(params ...interface{}) (bool, error) {
 	e.m.Lock()
 	defer e.m.Unlock()
 	return e.Enforcer.AddPolicy(params...)
+}
+
+// AddNamedPolicy adds an authorization rule to the current named policy.
+// If the rule already exists, the function returns false and the rule will not be added.
+// Otherwise the function returns true by adding the new rule.
+func (e *SyncedEnforcer) AddNamedPolicy(ptype string, params ...interface{}) (bool, error) {
+	e.m.Lock()
+	defer e.m.Unlock()
+	return e.Enforcer.AddNamedPolicy(ptype, params...)
 }
 
 // RemovePolicy removes an authorization rule from the current policy.
@@ -196,11 +268,32 @@ func (e *SyncedEnforcer) RemoveFilteredPolicy(fieldIndex int, fieldValues ...str
 	return e.Enforcer.RemoveFilteredPolicy(fieldIndex, fieldValues...)
 }
 
+// RemoveNamedPolicy removes an authorization rule from the current named policy.
+func (e *SyncedEnforcer) RemoveNamedPolicy(ptype string, params ...interface{}) (bool, error) {
+	e.m.Lock()
+	defer e.m.Unlock()
+	return e.Enforcer.RemoveNamedPolicy(ptype, params...)
+}
+
+// RemoveFilteredNamedPolicy removes an authorization rule from the current named policy, field filters can be specified.
+func (e *SyncedEnforcer) RemoveFilteredNamedPolicy(ptype string, fieldIndex int, fieldValues ...string) (bool, error) {
+	e.m.Lock()
+	defer e.m.Unlock()
+	return e.Enforcer.RemoveFilteredNamedPolicy(ptype, fieldIndex, fieldValues...)
+}
+
 // HasGroupingPolicy determines whether a role inheritance rule exists.
 func (e *SyncedEnforcer) HasGroupingPolicy(params ...interface{}) bool {
 	e.m.RLock()
 	defer e.m.RUnlock()
 	return e.Enforcer.HasGroupingPolicy(params...)
+}
+
+// HasNamedGroupingPolicy determines whether a named role inheritance rule exists.
+func (e *SyncedEnforcer) HasNamedGroupingPolicy(ptype string, params ...interface{}) bool {
+	e.m.RLock()
+	defer e.m.RUnlock()
+	return e.Enforcer.HasNamedGroupingPolicy(ptype, params...)
 }
 
 // AddGroupingPolicy adds a role inheritance rule to the current policy.
@@ -210,6 +303,15 @@ func (e *SyncedEnforcer) AddGroupingPolicy(params ...interface{}) (bool, error) 
 	e.m.Lock()
 	defer e.m.Unlock()
 	return e.Enforcer.AddGroupingPolicy(params...)
+}
+
+// AddNamedGroupingPolicy adds a named role inheritance rule to the current policy.
+// If the rule already exists, the function returns false and the rule will not be added.
+// Otherwise the function returns true by adding the new rule.
+func (e *SyncedEnforcer) AddNamedGroupingPolicy(ptype string, params ...interface{}) (bool, error) {
+	e.m.Lock()
+	defer e.m.Unlock()
+	return e.Enforcer.AddNamedGroupingPolicy(ptype, params...)
 }
 
 // RemoveGroupingPolicy removes a role inheritance rule from the current policy.
@@ -224,4 +326,25 @@ func (e *SyncedEnforcer) RemoveFilteredGroupingPolicy(fieldIndex int, fieldValue
 	e.m.Lock()
 	defer e.m.Unlock()
 	return e.Enforcer.RemoveFilteredGroupingPolicy(fieldIndex, fieldValues...)
+}
+
+// RemoveNamedGroupingPolicy removes a role inheritance rule from the current named policy.
+func (e *SyncedEnforcer) RemoveNamedGroupingPolicy(ptype string, params ...interface{}) (bool, error) {
+	e.m.Lock()
+	defer e.m.Unlock()
+	return e.Enforcer.RemoveNamedGroupingPolicy(ptype, params...)
+}
+
+// RemoveFilteredNamedGroupingPolicy removes a role inheritance rule from the current named policy, field filters can be specified.
+func (e *SyncedEnforcer) RemoveFilteredNamedGroupingPolicy(ptype string, fieldIndex int, fieldValues ...string) (bool, error) {
+	e.m.Lock()
+	defer e.m.Unlock()
+	return e.Enforcer.RemoveFilteredNamedGroupingPolicy(ptype, fieldIndex, fieldValues...)
+}
+
+// AddFunction adds a customized function.
+func (e *SyncedEnforcer) AddFunction(name string, function func(args ...interface{}) (interface{}, error)) {
+	e.m.Lock()
+	defer e.m.Unlock()
+	e.Enforcer.AddFunction(name, function)
 }


### PR DESCRIPTION
some methods in management_api are missing in SyncedEnforcer
those methods can fail when called while loading.
this PR adds those methods.