### PR TITLE
added getter for RoleManager

### DIFF
--- a/enforcer.go
+++ b/enforcer.go
@@ -213,6 +213,11 @@ func (e *Enforcer) SetWatcher(watcher persist.Watcher) error {
 	return watcher.SetUpdateCallback(func(string) { e.LoadPolicy() })
 }
 
+// GetRoleManager gets the current role manager.
+func (e *Enforcer) GetRoleManager() rbac.RoleManager {
+	return e.rm
+}
+
 // SetRoleManager sets the current role manager.
 func (e *Enforcer) SetRoleManager(rm rbac.RoleManager) {
 	e.rm = rm


### PR DESCRIPTION
Added getter for role manager. It was necessary to have a getter so as to use `AddMatchingFunc` method on the RoleManager struct.