### PR TITLE
Properly indent sample code in doc

### DIFF
--- a/enforcer.go
+++ b/enforcer.go
@@ -47,11 +47,16 @@ type Enforcer struct {
 }
 
 // NewEnforcer creates an enforcer via file or DB.
+//
 // File:
-// e := casbin.NewEnforcer("path/to/basic_model.conf", "path/to/basic_policy.csv")
+//
+// 	e := casbin.NewEnforcer("path/to/basic_model.conf", "path/to/basic_policy.csv")
+//
 // MySQL DB:
-// a := mysqladapter.NewDBAdapter("mysql", "mysql_username:mysql_password@tcp(127.0.0.1:3306)/")
-// e := casbin.NewEnforcer("path/to/basic_model.conf", a)
+//
+// 	a := mysqladapter.NewDBAdapter("mysql", "mysql_username:mysql_password@tcp(127.0.0.1:3306)/")
+// 	e := casbin.NewEnforcer("path/to/basic_model.conf", a)
+//
 func NewEnforcer(params ...interface{}) (*Enforcer, error) {
 	e := &Enforcer{}
 


### PR DESCRIPTION
According to this [official blog](https://blog.golang.org/godoc-documenting-go-code) one of the formatting rules for Godoc is

> Pre-formatted text must be indented relative to the surrounding comment text

This PR makes the code formatted properly in Godoc. I've skimmed through the doc and find this is the only part that need fixing. Please do let me know if I miss something. Thanks!

Here is a screenshot on Godoc that shows how it will look after the fix:

<img width="820" alt="Screen Shot 2019-10-15 at 13 32 22" src="https://user-images.githubusercontent.com/7593229/66800476-3ceb8180-ef50-11e9-8462-343539018157.png">
 