### PR TITLE
Handle panic in enforce

### DIFF
--- a/enforcer.go
+++ b/enforcer.go
@@ -338,6 +338,12 @@ func (e *Enforcer) BuildRoleLinks() error {
 
 // enforce use a custom matcher to decides whether a "subject" can access a "object" with the operation "action", input parameters are usually: (matcher, sub, obj, act), use model matcher by default when matcher is "".
 func (e *Enforcer) enforce(matcher string, rvals ...interface{}) (bool, error) {
+	defer func() {
+		if err := recover(); err != nil {
+			fmt.Errorf("panic: %v", err)
+		}
+	}()
+
 	if !e.enabled {
 		return true, nil
 	}


### PR DESCRIPTION
If a policy is not correctly defined, then throw an error instead of a panic:
https://github.com/casbin/casbin/issues/312