### PR TITLE
Fix syntax errors on multiline config sentences

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -149,6 +149,7 @@ func (c *Config) parseBuffer(buf *bufio.Reader) error {
 			var p []byte
 			if bytes.HasSuffix(line, DEFAULT_MULTI_LINE_SEPARATOR) {
 				p = bytes.TrimSpace(line[:len(line)-1])
+				p += " "
 			} else {
 				p = line
 				canWrite = true

--- a/config/testdata/testini.ini
+++ b/config/testdata/testini.ini
@@ -26,15 +26,15 @@ math.f64 = 64.1
 # multi-line test
 [multi1]
 name = r.sub==p.sub \
-   &&r.obj==p.obj\
+   && r.obj==p.obj\
    \
 [multi2]
 name = r.sub==p.sub \
-   &&r.obj==p.obj
+   && r.obj==p.obj
 
 [multi3]
 name = r.sub==p.sub \
-   &&r.obj==p.obj
+   && r.obj==p.obj
 
 [multi4]
 name = \
@@ -43,5 +43,5 @@ name = \
 
 [multi5]
 name = r.sub==p.sub \
-   &&r.obj==p.obj\
+   && r.obj==p.obj\
    \


### PR DESCRIPTION
- The actual code strips the multiline char but sometimes
it leads to syntax errors because not compatible chars may
result appended.