### PR TITLE
Fix syntax errors on multiline config sentences

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -149,6 +149,7 @@ func (c *Config) parseBuffer(buf *bufio.Reader) error {
 			var p []byte
 			if bytes.HasSuffix(line, DEFAULT_MULTI_LINE_SEPARATOR) {
 				p = bytes.TrimSpace(line[:len(line)-1])
+				p = append(p, " "...)
 			} else {
 				p = line
 				canWrite = true

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -63,15 +63,15 @@ func TestGet(t *testing.T) {
 
 	config.Set("other::key1", "test key")
 
-	if v := config.String("multi1::name"); v != "r.sub==p.sub&&r.obj==p.obj" {
+	if v := config.String("multi1::name"); v != "r.sub==p.sub && r.obj==p.obj" {
 		t.Errorf("Get failure: expected different value for multi1::name (expected: [%#v] got: [%#v])", "r.sub==p.sub&&r.obj==p.obj", v)
 	}
 
-	if v := config.String("multi2::name"); v != "r.sub==p.sub&&r.obj==p.obj" {
+	if v := config.String("multi2::name"); v != "r.sub==p.sub && r.obj==p.obj" {
 		t.Errorf("Get failure: expected different value for multi2::name (expected: [%#v] got: [%#v])", "r.sub==p.sub&&r.obj==p.obj", v)
 	}
 
-	if v := config.String("multi3::name"); v != "r.sub==p.sub&&r.obj==p.obj" {
+	if v := config.String("multi3::name"); v != "r.sub==p.sub && r.obj==p.obj" {
 		t.Errorf("Get failure: expected different value for multi3::name (expected: [%#v] got: [%#v])", "r.sub==p.sub&&r.obj==p.obj", v)
 	}
 
@@ -79,7 +79,7 @@ func TestGet(t *testing.T) {
 		t.Errorf("Get failure: expected different value for multi4::name (expected: [%#v] got: [%#v])", "", v)
 	}
 
-	if v := config.String("multi5::name"); v != "r.sub==p.sub&&r.obj==p.obj" {
+	if v := config.String("multi5::name"); v != "r.sub==p.sub && r.obj==p.obj" {
 		t.Errorf("Get failure: expected different value for multi5::name (expected: [%#v] got: [%#v])", "r.sub==p.sub&&r.obj==p.obj", v)
 	}
 }

--- a/config/testdata/testini.ini
+++ b/config/testdata/testini.ini
@@ -26,15 +26,15 @@ math.f64 = 64.1
 # multi-line test
 [multi1]
 name = r.sub==p.sub \
-   &&r.obj==p.obj\
+   && r.obj==p.obj\
    \
 [multi2]
 name = r.sub==p.sub \
-   &&r.obj==p.obj
+   && r.obj==p.obj
 
 [multi3]
 name = r.sub==p.sub \
-   &&r.obj==p.obj
+   && r.obj==p.obj
 
 [multi4]
 name = \
@@ -43,5 +43,5 @@ name = \
 
 [multi5]
 name = r.sub==p.sub \
-   &&r.obj==p.obj\
+   && r.obj==p.obj\
    \


### PR DESCRIPTION
- The actual code strips the multiline char but sometimes
it leads to syntax errors because not compatible chars may
result appended.