### PR TITLE
Go idomatic stopping goroutine for auto load policy

### DIFF
--- a/enforcer_synced_test.go
+++ b/enforcer_synced_test.go
@@ -43,3 +43,17 @@ func TestSync(t *testing.T) {
 	// Stop the reloading policy periodically.
 	e.StopAutoLoadPolicy()
 }
+
+func TestStopAutoLoadPolicy(t *testing.T) {
+	e, _ := NewSyncedEnforcer("examples/basic_model.conf", "examples/basic_policy.csv")
+	e.StartAutoLoadPolicy(5 * time.Millisecond)
+	if !e.autoLoadRunning {
+		t.Error("auto load is not running")
+	}
+	e.StopAutoLoadPolicy()
+	// Need a moment, to exit goroutine
+	time.Sleep(10 * time.Millisecond)
+	if e.autoLoadRunning {
+		t.Error("auto load is still running")
+	}
+}


### PR DESCRIPTION
Goroutine which is handling auto load policy is immediately exited after user requested to stop it, instead of sleeping.

After I commited, I realized maybe one issue?
StopAutoLoadPolicy will be blocking operation if there is no running auto load, can be solved again adding bool flag. But why user would want stop auto load policy if he didn't start it before.