### PR TITLE
fix(rbac_api.go): DeleteUser should remove Policies + Grouping Policies

### DIFF
--- a/rbac_api.go
+++ b/rbac_api.go
@@ -70,10 +70,18 @@ func (e *Enforcer) DeleteRolesForUser(user string) (bool, error) {
 // DeleteUser deletes a user.
 // Returns false if the user does not exist (aka not affected).
 func (e *Enforcer) DeleteUser(user string) (bool, error) {
-	return e.RemoveFilteredGroupingPolicy(0, user)
+	var err error
+	res1, err := e.RemoveFilteredGroupingPolicy(0, user)
+	if err != nil {
+		return res1, err
+	}
+
+	res2, err := e.RemoveFilteredPolicy(0, user)
+	return res1 || res2, err
 }
 
 // DeleteRole deletes a role.
+// Returns false if the role does not exist (aka not affected).
 func (e *Enforcer) DeleteRole(role string) (bool, error) {
 	var err error
 	res1, err := e.RemoveFilteredGroupingPolicy(1, role)

--- a/rbac_api_test.go
+++ b/rbac_api_test.go
@@ -104,7 +104,7 @@ func TestRoleAPI(t *testing.T) {
 
 	e.AddRoleForUser("alice", "data2_admin")
 
-	testEnforce(t, e, "alice", "data1", "read", true)
+	testEnforce(t, e, "alice", "data1", "read", false)
 	testEnforce(t, e, "alice", "data1", "write", false)
 	testEnforce(t, e, "alice", "data2", "read", true)
 	testEnforce(t, e, "alice", "data2", "write", true)
@@ -115,7 +115,7 @@ func TestRoleAPI(t *testing.T) {
 
 	e.DeleteRole("data2_admin")
 
-	testEnforce(t, e, "alice", "data1", "read", true)
+	testEnforce(t, e, "alice", "data1", "read", false)
 	testEnforce(t, e, "alice", "data1", "write", false)
 	testEnforce(t, e, "alice", "data2", "read", false)
 	testEnforce(t, e, "alice", "data2", "write", false)


### PR DESCRIPTION
Previously it just removed Grouping policies. Now it shares same implementation as DeleteRole
casbin/node-casbin#118