### PR TITLE
Extract Enforcer Interface and make Enforcers Chainable

### DIFF
--- a/enforcer.go
+++ b/enforcer.go
@@ -342,10 +342,10 @@ func (e *Enforcer) BuildRoleLinks() error {
 }
 
 // enforce use a custom matcher to decides whether a "subject" can access a "object" with the operation "action", input parameters are usually: (matcher, sub, obj, act), use model matcher by default when matcher is "".
-func (e *Enforcer) enforce(matcher string, rvals ...interface{}) (bool, error) {
+func (e *Enforcer) enforce(matcher string, rvals ...interface{}) (ok bool, err error) {
 	defer func() {
-		if err := recover(); err != nil {
-			fmt.Errorf("panic: %v", err)
+		if x := recover(); x != nil {
+			err = fmt.Errorf("panic: %v", x)
 		}
 	}()
 

--- a/enforcer.go
+++ b/enforcer.go
@@ -119,6 +119,10 @@ func NewEnforcer(params ...interface{}) (*Enforcer, error) {
 	return e, nil
 }
 
+func (e *Enforcer) GetParentEnforcer() BasicEnforcer {
+	return nil
+}
+
 // InitWithFile initializes an enforcer with a model file and a policy file.
 func (e *Enforcer) InitWithFile(modelPath string, policyPath string) error {
 	a := fileadapter.NewAdapter(policyPath)

--- a/enforcer.go
+++ b/enforcer.go
@@ -119,6 +119,7 @@ func NewEnforcer(params ...interface{}) (*Enforcer, error) {
 	return e, nil
 }
 
+// GetParentEnforcer always returns nil to support the BasicEnforcer interface.
 func (e *Enforcer) GetParentEnforcer() BasicEnforcer {
 	return nil
 }

--- a/enforcer_cached.go
+++ b/enforcer_cached.go
@@ -36,7 +36,7 @@ type CachedEnforcer struct {
 	locker      *sync.RWMutex
 }
 
-// NewCachedEnforcer creates a cached enforcer via file or DB.
+// NewCachedEnforcer creates a cached enforcer from an existing enforcer or via file or DB.
 func NewCachedEnforcer(params ...interface{}) (*CachedEnforcer, error) {
 	e := &CachedEnforcer{}
 	if len(params) == 1 {
@@ -68,12 +68,13 @@ func (e *CachedEnforcer) EnableCache(enableCache bool) {
 	e.enableCache = enableCache
 }
 
+// EnableAutoCLear determines whether to automatically invalidate the cache when the policy is changed.
 func (e *CachedEnforcer) EnableAutoClear(enableAuto bool) {
 	e.autoClear = enableAuto
 }
 
 // Enforce decides whether a "subject" can access a "object" with the operation "action", input parameters are usually: (sub, obj, act).
-// if rvals is not string , ingore the cache
+// if rvals is not string , ignore the cache
 func (e *CachedEnforcer) Enforce(rvals ...interface{}) (bool, error) {
 	if !e.enableCache {
 		return e.base.Enforce(rvals...)
@@ -123,10 +124,12 @@ func (e *CachedEnforcer) InvalidateCache() {
 	}
 }
 
+// GetParentEnforcer returns the parent enforcer wrapped by this instance.
 func (e *CachedEnforcer) GetParentEnforcer() BasicEnforcer {
 	return e.base
 }
 
+// InitWithFile initializes an enforcer with a model file and a policy file.
 func (e *CachedEnforcer) InitWithFile(modelPath string, policyPath string) error {
 	if e.autoClear {
 		defer e.InvalidateCache()
@@ -134,6 +137,7 @@ func (e *CachedEnforcer) InitWithFile(modelPath string, policyPath string) error
 	return e.base.InitWithFile(modelPath, policyPath)
 }
 
+// InitWithAdapter initializes an enforcer with a database adapter.
 func (e *CachedEnforcer) InitWithAdapter(modelPath string, adapter persist.Adapter) error {
 	if e.autoClear {
 		defer e.InvalidateCache()
@@ -141,6 +145,7 @@ func (e *CachedEnforcer) InitWithAdapter(modelPath string, adapter persist.Adapt
 	return e.base.InitWithAdapter(modelPath, adapter)
 }
 
+// InitWithModelAndAdapter initializes an enforcer with a model and a database adapter.
 func (e *CachedEnforcer) InitWithModelAndAdapter(m model.Model, adapter persist.Adapter) error {
 	if e.autoClear {
 		defer e.InvalidateCache()
@@ -148,6 +153,8 @@ func (e *CachedEnforcer) InitWithModelAndAdapter(m model.Model, adapter persist.
 	return e.base.InitWithModelAndAdapter(m, adapter)
 }
 
+// LoadModel reloads the model from the model CONF file.
+// Because the policy is attached to a model, so the policy is invalidated and needs to be reloaded by calling LoadPolicy().
 func (e *CachedEnforcer) LoadModel() error {
 	if e.autoClear {
 		defer e.InvalidateCache()
@@ -155,11 +162,13 @@ func (e *CachedEnforcer) LoadModel() error {
 	return e.base.LoadModel()
 }
 
+// GetModel gets the current model.
 func (e *CachedEnforcer) GetModel() model.Model {
 
 	return e.base.GetModel()
 }
 
+// SetModel sets the current model.
 func (e *CachedEnforcer) SetModel(m model.Model) {
 	if e.autoClear {
 		defer e.InvalidateCache()
@@ -167,10 +176,12 @@ func (e *CachedEnforcer) SetModel(m model.Model) {
 	e.base.SetModel(m)
 }
 
+// GetAdapter gets the current adapter.
 func (e *CachedEnforcer) GetAdapter() persist.Adapter {
 	return e.base.GetAdapter()
 }
 
+// SetAdapter sets the current adapter.
 func (e *CachedEnforcer) SetAdapter(adapter persist.Adapter) {
 	e.base.SetAdapter(adapter)
 }
@@ -180,10 +191,12 @@ func (e *CachedEnforcer) SetWatcher(watcher persist.Watcher) error {
 	return e.base.SetWatcher(watcher)
 }
 
+// GetRoleManager gets the current role manager.
 func (e *CachedEnforcer) GetRoleManager() rbac.RoleManager {
 	return e.base.GetRoleManager()
 }
 
+// SetRoleManager sets the current role manager.
 func (e *CachedEnforcer) SetRoleManager(rm rbac.RoleManager) {
 	e.base.SetRoleManager(rm)
 	if e.autoClear {
@@ -191,6 +204,7 @@ func (e *CachedEnforcer) SetRoleManager(rm rbac.RoleManager) {
 	}
 }
 
+// SetEffector sets the current effector.
 func (e *CachedEnforcer) SetEffector(eft effect.Effector) {
 	e.base.SetEffector(eft)
 	if e.autoClear {
@@ -214,6 +228,7 @@ func (e *CachedEnforcer) LoadPolicy() error {
 	return e.base.LoadPolicy()
 }
 
+// LoadFilteredPolicy reloads a filtered policy from file/database.
 func (e *CachedEnforcer) LoadFilteredPolicy(filter interface{}) error {
 	if e.autoClear {
 		defer e.InvalidateCache()
@@ -221,6 +236,7 @@ func (e *CachedEnforcer) LoadFilteredPolicy(filter interface{}) error {
 	return e.base.LoadFilteredPolicy(filter)
 }
 
+// IsFiltered returns true if the loaded policy has been filtered.
 func (e *CachedEnforcer) IsFiltered() bool {
 	return e.base.IsFiltered()
 }
@@ -230,18 +246,22 @@ func (e *CachedEnforcer) SavePolicy() error {
 	return e.base.SavePolicy()
 }
 
+// EnableEnforce changes the enforcing state of Casbin, when Casbin is disabled, all access will be allowed by the Enforce() function.
 func (e *CachedEnforcer) EnableEnforce(enable bool) {
 	e.base.EnableEnforce(enable)
 }
 
+// EnableLog changes whether Casbin will log messages to the Logger.
 func (e *CachedEnforcer) EnableLog(enable bool) {
 	e.base.EnableLog(enable)
 }
 
+// EnableAutoSave controls whether to save a policy rule automatically to the adapter when it is added or removed.
 func (e *CachedEnforcer) EnableAutoSave(autoSave bool) {
 	e.base.EnableAutoSave(autoSave)
 }
 
+// EnableAutoBuildRoleLinks controls whether to rebuild the role inheritance relations when a role is added or deleted.
 func (e *CachedEnforcer) EnableAutoBuildRoleLinks(autoBuildRoleLinks bool) {
 	e.base.EnableAutoBuildRoleLinks(autoBuildRoleLinks)
 }
@@ -251,6 +271,7 @@ func (e *CachedEnforcer) BuildRoleLinks() error {
 	return e.base.BuildRoleLinks()
 }
 
+// EnforceWithMatcher use a custom matcher to decides whether a "subject" can access a "object" with the operation "action", input parameters are usually: (matcher, sub, obj, act), use model matcher by default when matcher is "".
 func (e *CachedEnforcer) EnforceWithMatcher(matcher string, rvals ...interface{}) (bool, error) {
 	return e.base.EnforceWithMatcher(matcher, rvals)
 }
@@ -464,14 +485,39 @@ func (e *CachedEnforcer) AddFunction(name string, function govaluate.ExpressionF
 	e.api.AddFunction(name, function)
 }
 
+// GetImplicitPermissionsForUser gets implicit permissions for a user or role.
+// Compared to GetPermissionsForUser(), this function retrieves permissions for inherited roles.
+// For example:
+// p, admin, data1, read
+// p, alice, data2, read
+// g, alice, admin
+//
+// GetPermissionsForUser("alice") can only get: [["alice", "data2", "read"]].
+// But GetImplicitPermissionsForUser("alice") will get: [["admin", "data1", "read"], ["alice", "data2", "read"]].
 func (e *CachedEnforcer) GetImplicitPermissionsForUser(user string, domain ...string) ([][]string, error) {
 	return e.api.GetImplicitPermissionsForUser(user, domain...)
 }
 
+// GetImplicitRolesForUser gets implicit roles that a user has.
+// Compared to GetRolesForUser(), this function retrieves indirect roles besides direct roles.
+// For example:
+// g, alice, role:admin
+// g, role:admin, role:user
+//
+// GetRolesForUser("alice") can only get: ["role:admin"].
+// But GetImplicitRolesForUser("alice") will get: ["role:admin", "role:user"].
 func (e *CachedEnforcer) GetImplicitRolesForUser(user string, domain ...string) ([]string, error) {
 	return e.api.GetImplicitRolesForUser(user, domain...)
 }
 
+// GetImplicitUsersForPermission gets implicit users for a permission.
+// For example:
+// p, admin, data1, read
+// p, bob, data1, read
+// g, alice, admin
+//
+// GetImplicitUsersForPermission("data1", "read") will get: ["alice", "bob"].
+// Note: only users will be returned, roles (2nd arg in "g") will be excluded.
 func (e *CachedEnforcer) GetImplicitUsersForPermission(permission ...string) ([]string, error) {
 	return e.api.GetImplicitUsersForPermission(permission...)
 }

--- a/enforcer_cached.go
+++ b/enforcer_cached.go
@@ -17,23 +17,44 @@ package casbin
 import (
 	"strings"
 	"sync"
+
+	"github.com/Knetic/govaluate"
+
+	"github.com/casbin/casbin/v2/effect"
+	"github.com/casbin/casbin/v2/model"
+	"github.com/casbin/casbin/v2/persist"
+	"github.com/casbin/casbin/v2/rbac"
 )
 
 // CachedEnforcer wraps Enforcer and provides decision cache
 type CachedEnforcer struct {
-	*Enforcer
+	base        BasicEnforcer
+	api         APIEnforcer
 	m           map[string]bool
 	enableCache bool
+	autoClear   bool
 	locker      *sync.RWMutex
 }
 
 // NewCachedEnforcer creates a cached enforcer via file or DB.
 func NewCachedEnforcer(params ...interface{}) (*CachedEnforcer, error) {
 	e := &CachedEnforcer{}
-	var err error
-	e.Enforcer, err = NewEnforcer(params...)
-	if err != nil {
-		return nil, err
+	if len(params) == 1 {
+		if parent, ok := params[0].(FullEnforcer); ok {
+			e.base = parent
+			e.api = parent
+		} else if parent, ok := params[0].(BasicEnforcer); ok {
+			e.base = parent
+			e.api = &DummyEnforcer{}
+		}
+	}
+	if e.base == nil {
+		ef, err := NewEnforcer(params...)
+		if err != nil {
+			return nil, err
+		}
+		e.base = ef
+		e.api = ef
 	}
 
 	e.enableCache = true
@@ -47,11 +68,15 @@ func (e *CachedEnforcer) EnableCache(enableCache bool) {
 	e.enableCache = enableCache
 }
 
+func (e *CachedEnforcer) EnableAutoClear(enableAuto bool) {
+	e.autoClear = enableAuto
+}
+
 // Enforce decides whether a "subject" can access a "object" with the operation "action", input parameters are usually: (sub, obj, act).
 // if rvals is not string , ingore the cache
 func (e *CachedEnforcer) Enforce(rvals ...interface{}) (bool, error) {
 	if !e.enableCache {
-		return e.Enforcer.Enforce(rvals...)
+		return e.base.Enforce(rvals...)
 	}
 
 	var key strings.Builder
@@ -60,14 +85,14 @@ func (e *CachedEnforcer) Enforce(rvals ...interface{}) (bool, error) {
 			key.WriteString(val)
 			key.WriteString("$$")
 		} else {
-			return e.Enforcer.Enforce(rvals...)
+			return e.base.Enforce(rvals...)
 		}
 	}
 
 	if res, ok := e.getCachedResult(key.String()); ok {
 		return res, nil
 	}
-	res, err := e.Enforcer.Enforce(rvals...)
+	res, err := e.base.Enforce(rvals...)
 	if err != nil {
 		return false, err
 	}
@@ -91,5 +116,362 @@ func (e *CachedEnforcer) setCachedResult(key string, res bool) {
 
 // InvalidateCache deletes all the existing cached decisions.
 func (e *CachedEnforcer) InvalidateCache() {
-	e.m = make(map[string]bool)
+	e.locker.Lock()
+	defer e.locker.Unlock()
+	if len(e.m) > 0 {
+		e.m = make(map[string]bool)
+	}
+}
+
+func (e *CachedEnforcer) GetParentEnforcer() BasicEnforcer {
+	return e.base
+}
+
+func (e *CachedEnforcer) InitWithFile(modelPath string, policyPath string) error {
+	if e.autoClear {
+		defer e.InvalidateCache()
+	}
+	return e.base.InitWithFile(modelPath, policyPath)
+}
+
+func (e *CachedEnforcer) InitWithAdapter(modelPath string, adapter persist.Adapter) error {
+	if e.autoClear {
+		defer e.InvalidateCache()
+	}
+	return e.base.InitWithAdapter(modelPath, adapter)
+}
+
+func (e *CachedEnforcer) InitWithModelAndAdapter(m model.Model, adapter persist.Adapter) error {
+	if e.autoClear {
+		defer e.InvalidateCache()
+	}
+	return e.base.InitWithModelAndAdapter(m, adapter)
+}
+
+func (e *CachedEnforcer) LoadModel() error {
+	if e.autoClear {
+		defer e.InvalidateCache()
+	}
+	return e.base.LoadModel()
+}
+
+func (e *CachedEnforcer) GetModel() model.Model {
+
+	return e.base.GetModel()
+}
+
+func (e *CachedEnforcer) SetModel(m model.Model) {
+	if e.autoClear {
+		defer e.InvalidateCache()
+	}
+	e.base.SetModel(m)
+}
+
+func (e *CachedEnforcer) GetAdapter() persist.Adapter {
+	return e.base.GetAdapter()
+}
+
+func (e *CachedEnforcer) SetAdapter(adapter persist.Adapter) {
+	e.base.SetAdapter(adapter)
+}
+
+// SetWatcher sets the current watcher.
+func (e *CachedEnforcer) SetWatcher(watcher persist.Watcher) error {
+	return e.base.SetWatcher(watcher)
+}
+
+func (e *CachedEnforcer) GetRoleManager() rbac.RoleManager {
+	return e.base.GetRoleManager()
+}
+
+func (e *CachedEnforcer) SetRoleManager(rm rbac.RoleManager) {
+	e.base.SetRoleManager(rm)
+	if e.autoClear {
+		e.InvalidateCache()
+	}
+}
+
+func (e *CachedEnforcer) SetEffector(eft effect.Effector) {
+	e.base.SetEffector(eft)
+	if e.autoClear {
+		e.InvalidateCache()
+	}
+}
+
+// ClearPolicy clears all policy.
+func (e *CachedEnforcer) ClearPolicy() {
+	e.base.ClearPolicy()
+	if e.autoClear {
+		e.InvalidateCache()
+	}
+}
+
+// LoadPolicy reloads the policy from file/database.
+func (e *CachedEnforcer) LoadPolicy() error {
+	if e.autoClear {
+		defer e.InvalidateCache()
+	}
+	return e.base.LoadPolicy()
+}
+
+func (e *CachedEnforcer) LoadFilteredPolicy(filter interface{}) error {
+	if e.autoClear {
+		defer e.InvalidateCache()
+	}
+	return e.base.LoadFilteredPolicy(filter)
+}
+
+func (e *CachedEnforcer) IsFiltered() bool {
+	return e.base.IsFiltered()
+}
+
+// SavePolicy saves the current policy (usually after changed with Casbin API) back to file/database.
+func (e *CachedEnforcer) SavePolicy() error {
+	return e.base.SavePolicy()
+}
+
+func (e *CachedEnforcer) EnableEnforce(enable bool) {
+	e.base.EnableEnforce(enable)
+}
+
+func (e *CachedEnforcer) EnableLog(enable bool) {
+	e.base.EnableLog(enable)
+}
+
+func (e *CachedEnforcer) EnableAutoSave(autoSave bool) {
+	e.base.EnableAutoSave(autoSave)
+}
+
+func (e *CachedEnforcer) EnableAutoBuildRoleLinks(autoBuildRoleLinks bool) {
+	e.base.EnableAutoBuildRoleLinks(autoBuildRoleLinks)
+}
+
+// BuildRoleLinks manually rebuild the role inheritance relations.
+func (e *CachedEnforcer) BuildRoleLinks() error {
+	return e.base.BuildRoleLinks()
+}
+
+func (e *CachedEnforcer) EnforceWithMatcher(matcher string, rvals ...interface{}) (bool, error) {
+	return e.base.EnforceWithMatcher(matcher, rvals)
+}
+
+// GetAllSubjects gets the list of subjects that show up in the current policy.
+func (e *CachedEnforcer) GetAllSubjects() []string {
+	return e.api.GetAllSubjects()
+}
+
+// GetAllNamedSubjects gets the list of subjects that show up in the current named policy.
+func (e *CachedEnforcer) GetAllNamedSubjects(ptype string) []string {
+	return e.api.GetAllNamedSubjects(ptype)
+}
+
+// GetAllObjects gets the list of objects that show up in the current policy.
+func (e *CachedEnforcer) GetAllObjects() []string {
+	return e.api.GetAllObjects()
+}
+
+// GetAllNamedObjects gets the list of objects that show up in the current named policy.
+func (e *CachedEnforcer) GetAllNamedObjects(ptype string) []string {
+	return e.api.GetAllNamedObjects(ptype)
+}
+
+// GetAllActions gets the list of actions that show up in the current policy.
+func (e *CachedEnforcer) GetAllActions() []string {
+	return e.api.GetAllActions()
+}
+
+// GetAllNamedActions gets the list of actions that show up in the current named policy.
+func (e *CachedEnforcer) GetAllNamedActions(ptype string) []string {
+	return e.api.GetAllNamedActions(ptype)
+}
+
+// GetAllRoles gets the list of roles that show up in the current policy.
+func (e *CachedEnforcer) GetAllRoles() []string {
+	return e.api.GetAllRoles()
+}
+
+// GetAllNamedRoles gets the list of roles that show up in the current named policy.
+func (e *CachedEnforcer) GetAllNamedRoles(ptype string) []string {
+	return e.api.GetAllNamedRoles(ptype)
+}
+
+// GetPolicy gets all the authorization rules in the policy.
+func (e *CachedEnforcer) GetPolicy() [][]string {
+	return e.api.GetPolicy()
+}
+
+// GetFilteredPolicy gets all the authorization rules in the policy, field filters can be specified.
+func (e *CachedEnforcer) GetFilteredPolicy(fieldIndex int, fieldValues ...string) [][]string {
+	return e.api.GetFilteredPolicy(fieldIndex, fieldValues...)
+}
+
+// GetNamedPolicy gets all the authorization rules in the named policy.
+func (e *CachedEnforcer) GetNamedPolicy(ptype string) [][]string {
+	return e.api.GetNamedPolicy(ptype)
+}
+
+// GetFilteredNamedPolicy gets all the authorization rules in the named policy, field filters can be specified.
+func (e *CachedEnforcer) GetFilteredNamedPolicy(ptype string, fieldIndex int, fieldValues ...string) [][]string {
+	return e.api.GetFilteredNamedPolicy(ptype, fieldIndex, fieldValues...)
+}
+
+// GetGroupingPolicy gets all the role inheritance rules in the policy.
+func (e *CachedEnforcer) GetGroupingPolicy() [][]string {
+	return e.api.GetGroupingPolicy()
+}
+
+// GetFilteredGroupingPolicy gets all the role inheritance rules in the policy, field filters can be specified.
+func (e *CachedEnforcer) GetFilteredGroupingPolicy(fieldIndex int, fieldValues ...string) [][]string {
+	return e.api.GetFilteredGroupingPolicy(fieldIndex, fieldValues...)
+}
+
+// GetNamedGroupingPolicy gets all the role inheritance rules in the policy.
+func (e *CachedEnforcer) GetNamedGroupingPolicy(ptype string) [][]string {
+	return e.api.GetNamedGroupingPolicy(ptype)
+}
+
+// GetFilteredNamedGroupingPolicy gets all the role inheritance rules in the policy, field filters can be specified.
+func (e *CachedEnforcer) GetFilteredNamedGroupingPolicy(ptype string, fieldIndex int, fieldValues ...string) [][]string {
+	return e.api.GetFilteredNamedGroupingPolicy(ptype, fieldIndex, fieldValues...)
+}
+
+// HasPolicy determines whether an authorization rule exists.
+func (e *CachedEnforcer) HasPolicy(params ...interface{}) bool {
+	return e.api.HasPolicy(params...)
+}
+
+// HasNamedPolicy determines whether a named authorization rule exists.
+func (e *CachedEnforcer) HasNamedPolicy(ptype string, params ...interface{}) bool {
+	return e.api.HasNamedPolicy(ptype, params...)
+}
+
+// AddPolicy adds an authorization rule to the current policy.
+// If the rule already exists, the function returns false and the rule will not be added.
+// Otherwise the function returns true by adding the new rule.
+func (e *CachedEnforcer) AddPolicy(params ...interface{}) (bool, error) {
+	if e.autoClear {
+		defer e.InvalidateCache()
+	}
+	return e.api.AddPolicy(params...)
+}
+
+// AddNamedPolicy adds an authorization rule to the current named policy.
+// If the rule already exists, the function returns false and the rule will not be added.
+// Otherwise the function returns true by adding the new rule.
+func (e *CachedEnforcer) AddNamedPolicy(ptype string, params ...interface{}) (bool, error) {
+	if e.autoClear {
+		defer e.InvalidateCache()
+	}
+	return e.api.AddNamedPolicy(ptype, params...)
+}
+
+// RemovePolicy removes an authorization rule from the current policy.
+func (e *CachedEnforcer) RemovePolicy(params ...interface{}) (bool, error) {
+	if e.autoClear {
+		defer e.InvalidateCache()
+	}
+	return e.api.RemovePolicy(params...)
+}
+
+// RemoveFilteredPolicy removes an authorization rule from the current policy, field filters can be specified.
+func (e *CachedEnforcer) RemoveFilteredPolicy(fieldIndex int, fieldValues ...string) (bool, error) {
+	if e.autoClear {
+		defer e.InvalidateCache()
+	}
+	return e.api.RemoveFilteredPolicy(fieldIndex, fieldValues...)
+}
+
+// RemoveNamedPolicy removes an authorization rule from the current named policy.
+func (e *CachedEnforcer) RemoveNamedPolicy(ptype string, params ...interface{}) (bool, error) {
+	if e.autoClear {
+		defer e.InvalidateCache()
+	}
+	return e.api.RemoveNamedPolicy(ptype, params...)
+}
+
+// RemoveFilteredNamedPolicy removes an authorization rule from the current named policy, field filters can be specified.
+func (e *CachedEnforcer) RemoveFilteredNamedPolicy(ptype string, fieldIndex int, fieldValues ...string) (bool, error) {
+	if e.autoClear {
+		defer e.InvalidateCache()
+	}
+	return e.api.RemoveFilteredNamedPolicy(ptype, fieldIndex, fieldValues...)
+}
+
+// HasGroupingPolicy determines whether a role inheritance rule exists.
+func (e *CachedEnforcer) HasGroupingPolicy(params ...interface{}) bool {
+	return e.api.HasGroupingPolicy(params...)
+}
+
+// HasNamedGroupingPolicy determines whether a named role inheritance rule exists.
+func (e *CachedEnforcer) HasNamedGroupingPolicy(ptype string, params ...interface{}) bool {
+	return e.api.HasNamedGroupingPolicy(ptype, params...)
+}
+
+// AddGroupingPolicy adds a role inheritance rule to the current policy.
+// If the rule already exists, the function returns false and the rule will not be added.
+// Otherwise the function returns true by adding the new rule.
+func (e *CachedEnforcer) AddGroupingPolicy(params ...interface{}) (bool, error) {
+	if e.autoClear {
+		defer e.InvalidateCache()
+	}
+	return e.api.AddGroupingPolicy(params...)
+}
+
+// AddNamedGroupingPolicy adds a named role inheritance rule to the current policy.
+// If the rule already exists, the function returns false and the rule will not be added.
+// Otherwise the function returns true by adding the new rule.
+func (e *CachedEnforcer) AddNamedGroupingPolicy(ptype string, params ...interface{}) (bool, error) {
+	if e.autoClear {
+		defer e.InvalidateCache()
+	}
+	return e.api.AddNamedGroupingPolicy(ptype, params...)
+}
+
+// RemoveGroupingPolicy removes a role inheritance rule from the current policy.
+func (e *CachedEnforcer) RemoveGroupingPolicy(params ...interface{}) (bool, error) {
+	if e.autoClear {
+		defer e.InvalidateCache()
+	}
+	return e.api.RemoveGroupingPolicy(params...)
+}
+
+// RemoveFilteredGroupingPolicy removes a role inheritance rule from the current policy, field filters can be specified.
+func (e *CachedEnforcer) RemoveFilteredGroupingPolicy(fieldIndex int, fieldValues ...string) (bool, error) {
+	if e.autoClear {
+		defer e.InvalidateCache()
+	}
+	return e.api.RemoveFilteredGroupingPolicy(fieldIndex, fieldValues...)
+}
+
+// RemoveNamedGroupingPolicy removes a role inheritance rule from the current named policy.
+func (e *CachedEnforcer) RemoveNamedGroupingPolicy(ptype string, params ...interface{}) (bool, error) {
+	if e.autoClear {
+		defer e.InvalidateCache()
+	}
+	return e.api.RemoveNamedGroupingPolicy(ptype, params...)
+}
+
+// RemoveFilteredNamedGroupingPolicy removes a role inheritance rule from the current named policy, field filters can be specified.
+func (e *CachedEnforcer) RemoveFilteredNamedGroupingPolicy(ptype string, fieldIndex int, fieldValues ...string) (bool, error) {
+	if e.autoClear {
+		defer e.InvalidateCache()
+	}
+	return e.api.RemoveFilteredNamedGroupingPolicy(ptype, fieldIndex, fieldValues...)
+}
+
+// AddFunction adds a customized function.
+func (e *CachedEnforcer) AddFunction(name string, function govaluate.ExpressionFunction) {
+	e.api.AddFunction(name, function)
+}
+
+func (e *CachedEnforcer) GetImplicitPermissionsForUser(user string, domain ...string) ([][]string, error) {
+	return e.api.GetImplicitPermissionsForUser(user, domain...)
+}
+
+func (e *CachedEnforcer) GetImplicitRolesForUser(user string, domain ...string) ([]string, error) {
+	return e.api.GetImplicitRolesForUser(user, domain...)
+}
+
+func (e *CachedEnforcer) GetImplicitUsersForPermission(permission ...string) ([]string, error) {
+	return e.api.GetImplicitUsersForPermission(permission...)
 }

--- a/enforcer_cached.go
+++ b/enforcer_cached.go
@@ -28,6 +28,7 @@ import (
 
 // CachedEnforcer wraps Enforcer and provides decision cache
 type CachedEnforcer struct {
+	Enforcer    *Enforcer
 	base        BasicEnforcer
 	api         APIEnforcer
 	m           map[string]bool
@@ -57,6 +58,7 @@ func NewCachedEnforcer(params ...interface{}) (*CachedEnforcer, error) {
 		e.api = ef
 	}
 
+	e.Enforcer = GetRootEnforcer(e.base)
 	e.enableCache = true
 	e.m = make(map[string]bool)
 	e.locker = new(sync.RWMutex)

--- a/enforcer_dummy.go
+++ b/enforcer_dummy.go
@@ -1,0 +1,246 @@
+// Copyright 2017 The casbin Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package casbin
+
+import (
+	"errors"
+
+	"github.com/Knetic/govaluate"
+)
+
+type DummyEnforcer struct {
+}
+
+var ErrorUnsupported = errors.New("unsupported function")
+
+func (e *DummyEnforcer) GetRolesForUser(name string) ([]string, error) {
+	return nil, ErrorUnsupported
+}
+
+func (e *DummyEnforcer) GetUsersForRole(name string) ([]string, error) {
+	return nil, ErrorUnsupported
+}
+
+func (e *DummyEnforcer) HasRoleForUser(name string, role string) (bool, error) {
+	return false, ErrorUnsupported
+}
+
+func (e *DummyEnforcer) AddRoleForUser(user string, role string) (bool, error) {
+	return false, ErrorUnsupported
+}
+
+func (e *DummyEnforcer) DeleteRoleForUser(user string, role string) (bool, error) {
+	return false, ErrorUnsupported
+}
+
+func (e *DummyEnforcer) DeleteRolesForUser(user string) (bool, error) {
+	return false, ErrorUnsupported
+}
+
+func (e *DummyEnforcer) DeleteUser(user string) (bool, error) {
+	return false, ErrorUnsupported
+}
+
+func (e *DummyEnforcer) DeleteRole(role string) (bool, error) {
+	return false, ErrorUnsupported
+}
+
+func (e *DummyEnforcer) DeletePermission(permission ...string) (bool, error) {
+	return false, ErrorUnsupported
+}
+
+func (e *DummyEnforcer) AddPermissionForUser(user string, permission ...string) (bool, error) {
+	return false, ErrorUnsupported
+}
+
+func (e *DummyEnforcer) DeletePermissionForUser(user string, permission ...string) (bool, error) {
+	return false, ErrorUnsupported
+}
+
+func (e *DummyEnforcer) DeletePermissionsForUser(user string) (bool, error) {
+	return false, ErrorUnsupported
+}
+
+func (e *DummyEnforcer) GetPermissionsForUser(user string) [][]string {
+	return nil
+}
+
+func (e *DummyEnforcer) HasPermissionForUser(user string, permission ...string) bool {
+	return false
+}
+
+func (e *DummyEnforcer) GetImplicitRolesForUser(name string, domain ...string) ([]string, error) {
+	return nil, ErrorUnsupported
+}
+
+func (e *DummyEnforcer) GetImplicitPermissionsForUser(user string, domain ...string) ([][]string, error) {
+	return nil, ErrorUnsupported
+}
+
+func (e *DummyEnforcer) GetImplicitUsersForPermission(permission ...string) ([]string, error) {
+	return nil, ErrorUnsupported
+}
+
+func (e *DummyEnforcer) GetUsersForRoleInDomain(name string, domain string) []string {
+	return nil
+}
+
+func (e *DummyEnforcer) GetRolesForUserInDomain(name string, domain string) []string {
+	return nil
+}
+
+func (e *DummyEnforcer) GetPermissionsForUserInDomain(user string, domain string) [][]string {
+	return nil
+}
+
+func (e *DummyEnforcer) AddRoleForUserInDomain(user string, role string, domain string) (bool, error) {
+	return false, ErrorUnsupported
+}
+
+func (e *DummyEnforcer) DeleteRoleForUserInDomain(user string, role string, domain string) (bool, error) {
+	return false, ErrorUnsupported
+}
+
+func (e *DummyEnforcer) GetAllSubjects() []string {
+	return nil
+}
+
+func (e *DummyEnforcer) GetAllNamedSubjects(ptype string) []string {
+	return nil
+}
+
+func (e *DummyEnforcer) GetAllObjects() []string {
+	return nil
+}
+
+func (e *DummyEnforcer) GetAllNamedObjects(ptype string) []string {
+	return nil
+}
+
+func (e *DummyEnforcer) GetAllActions() []string {
+	return nil
+}
+
+func (e *DummyEnforcer) GetAllNamedActions(ptype string) []string {
+	return nil
+}
+
+func (e *DummyEnforcer) GetAllRoles() []string {
+	return nil
+}
+
+func (e *DummyEnforcer) GetAllNamedRoles(ptype string) []string {
+	return nil
+}
+
+func (e *DummyEnforcer) GetPolicy() [][]string {
+	return nil
+}
+
+func (e *DummyEnforcer) GetFilteredPolicy(fieldIndex int, fieldValues ...string) [][]string {
+	return nil
+}
+
+func (e *DummyEnforcer) GetNamedPolicy(ptype string) [][]string {
+	return nil
+}
+
+func (e *DummyEnforcer) GetFilteredNamedPolicy(ptype string, fieldIndex int, fieldValues ...string) [][]string {
+	return nil
+}
+
+func (e *DummyEnforcer) GetGroupingPolicy() [][]string {
+	return nil
+}
+
+func (e *DummyEnforcer) GetFilteredGroupingPolicy(fieldIndex int, fieldValues ...string) [][]string {
+	return nil
+}
+
+func (e *DummyEnforcer) GetNamedGroupingPolicy(ptype string) [][]string {
+	return nil
+}
+
+func (e *DummyEnforcer) GetFilteredNamedGroupingPolicy(ptype string, fieldIndex int, fieldValues ...string) [][]string {
+	return nil
+}
+
+func (e *DummyEnforcer) HasPolicy(params ...interface{}) bool {
+	return false
+}
+
+func (e *DummyEnforcer) HasNamedPolicy(ptype string, params ...interface{}) bool {
+	return false
+}
+
+func (e *DummyEnforcer) AddPolicy(params ...interface{}) (bool, error) {
+	return false, ErrorUnsupported
+}
+
+func (e *DummyEnforcer) AddNamedPolicy(ptype string, params ...interface{}) (bool, error) {
+	return false, ErrorUnsupported
+}
+
+func (e *DummyEnforcer) RemovePolicy(params ...interface{}) (bool, error) {
+	return false, ErrorUnsupported
+}
+
+func (e *DummyEnforcer) RemoveFilteredPolicy(fieldIndex int, fieldValues ...string) (bool, error) {
+	return false, ErrorUnsupported
+}
+
+func (e *DummyEnforcer) RemoveNamedPolicy(ptype string, params ...interface{}) (bool, error) {
+	return false, ErrorUnsupported
+}
+
+func (e *DummyEnforcer) RemoveFilteredNamedPolicy(ptype string, fieldIndex int, fieldValues ...string) (bool, error) {
+	return false, ErrorUnsupported
+}
+
+func (e *DummyEnforcer) HasGroupingPolicy(params ...interface{}) bool {
+	return false
+}
+
+func (e *DummyEnforcer) HasNamedGroupingPolicy(ptype string, params ...interface{}) bool {
+	return false
+}
+
+func (e *DummyEnforcer) AddGroupingPolicy(params ...interface{}) (bool, error) {
+	return false, ErrorUnsupported
+}
+
+func (e *DummyEnforcer) AddNamedGroupingPolicy(ptype string, params ...interface{}) (bool, error) {
+	return false, ErrorUnsupported
+}
+
+func (e *DummyEnforcer) RemoveGroupingPolicy(params ...interface{}) (bool, error) {
+	return false, ErrorUnsupported
+}
+
+func (e *DummyEnforcer) RemoveFilteredGroupingPolicy(fieldIndex int, fieldValues ...string) (bool, error) {
+	return false, ErrorUnsupported
+}
+
+func (e *DummyEnforcer) RemoveNamedGroupingPolicy(ptype string, params ...interface{}) (bool, error) {
+	return false, ErrorUnsupported
+}
+
+func (e *DummyEnforcer) RemoveFilteredNamedGroupingPolicy(ptype string, fieldIndex int, fieldValues ...string) (bool, error) {
+	return false, ErrorUnsupported
+}
+
+func (e *DummyEnforcer) AddFunction(name string, function govaluate.ExpressionFunction) {
+	return
+}

--- a/enforcer_dummy.go
+++ b/enforcer_dummy.go
@@ -20,227 +20,287 @@ import (
 	"github.com/Knetic/govaluate"
 )
 
+// DummyEnforcer is a dummy implementation of APIEnforcer which simply returns either
+// nil or ErrorUnsupported on all function calls.
+// DummyEnforcer is used to provide functionality to enforcer wrappers which do not
+// implement APIEnforcer
 type DummyEnforcer struct {
 }
 
+// ErrorUnsupported is returned to indicate that a specific function is not supported by an enforcer wrapper
 var ErrorUnsupported = errors.New("unsupported function")
 
+// GetRolesForUser returns nil and ErrorUnsupported
 func (e *DummyEnforcer) GetRolesForUser(name string) ([]string, error) {
 	return nil, ErrorUnsupported
 }
 
+// GetUsersForRole returns nil and ErrorUnsupported
 func (e *DummyEnforcer) GetUsersForRole(name string) ([]string, error) {
 	return nil, ErrorUnsupported
 }
 
+// HasRoleForUser returns false and ErrorUnsupported
 func (e *DummyEnforcer) HasRoleForUser(name string, role string) (bool, error) {
 	return false, ErrorUnsupported
 }
 
+// AddRoleForUser returns false and ErrorUnsupported
 func (e *DummyEnforcer) AddRoleForUser(user string, role string) (bool, error) {
 	return false, ErrorUnsupported
 }
 
+// DeleteRoleForUser returns false and ErrorUnsupported
 func (e *DummyEnforcer) DeleteRoleForUser(user string, role string) (bool, error) {
 	return false, ErrorUnsupported
 }
 
+// DeleteRolesForUser returns false and ErrorUnsupported
 func (e *DummyEnforcer) DeleteRolesForUser(user string) (bool, error) {
 	return false, ErrorUnsupported
 }
 
+// DeleteUser returns false and ErrorUnsupported
 func (e *DummyEnforcer) DeleteUser(user string) (bool, error) {
 	return false, ErrorUnsupported
 }
 
+// DeleteRole returns false and ErrorUnsupported
 func (e *DummyEnforcer) DeleteRole(role string) (bool, error) {
 	return false, ErrorUnsupported
 }
 
+// DeletePermission returns false and ErrorUnsupported
 func (e *DummyEnforcer) DeletePermission(permission ...string) (bool, error) {
 	return false, ErrorUnsupported
 }
 
+// AddPermissionForUser returns false and ErrorUnsupported
 func (e *DummyEnforcer) AddPermissionForUser(user string, permission ...string) (bool, error) {
 	return false, ErrorUnsupported
 }
 
+// DeletePermissionForUser returns false and ErrorUnsupported
 func (e *DummyEnforcer) DeletePermissionForUser(user string, permission ...string) (bool, error) {
 	return false, ErrorUnsupported
 }
 
+// DeletePermissionsForUser returns false and ErrorUnsupported
 func (e *DummyEnforcer) DeletePermissionsForUser(user string) (bool, error) {
 	return false, ErrorUnsupported
 }
 
+// GetPermissionsForUser returns nil
 func (e *DummyEnforcer) GetPermissionsForUser(user string) [][]string {
 	return nil
 }
 
+// HasPermissionForUser returns false
 func (e *DummyEnforcer) HasPermissionForUser(user string, permission ...string) bool {
 	return false
 }
 
+// GetImplicitRolesForUser returns nil and ErrorUnsupported
 func (e *DummyEnforcer) GetImplicitRolesForUser(name string, domain ...string) ([]string, error) {
 	return nil, ErrorUnsupported
 }
 
+// GetImplicitPermissionsForUser returns nil and ErrorUnsupported
 func (e *DummyEnforcer) GetImplicitPermissionsForUser(user string, domain ...string) ([][]string, error) {
 	return nil, ErrorUnsupported
 }
 
+// GetImplicitUsersForPermission returns nil and ErrorUnsupported
 func (e *DummyEnforcer) GetImplicitUsersForPermission(permission ...string) ([]string, error) {
 	return nil, ErrorUnsupported
 }
 
+// GetUsersForRoleInDomain returns nil
 func (e *DummyEnforcer) GetUsersForRoleInDomain(name string, domain string) []string {
 	return nil
 }
 
+// GetRolesForUserInDomain returns nil
 func (e *DummyEnforcer) GetRolesForUserInDomain(name string, domain string) []string {
 	return nil
 }
 
+// GetPermissionsForUserInDomain returns nil
 func (e *DummyEnforcer) GetPermissionsForUserInDomain(user string, domain string) [][]string {
 	return nil
 }
 
+// AddRoleForUserInDomain returns false and ErrorUnsupported
 func (e *DummyEnforcer) AddRoleForUserInDomain(user string, role string, domain string) (bool, error) {
 	return false, ErrorUnsupported
 }
 
+// DeleteRoleForUserInDomain returns false and ErrorUnsupported
 func (e *DummyEnforcer) DeleteRoleForUserInDomain(user string, role string, domain string) (bool, error) {
 	return false, ErrorUnsupported
 }
 
+// GetAllSubjects returns nil
 func (e *DummyEnforcer) GetAllSubjects() []string {
 	return nil
 }
 
+// GetAllNamedSubjects returns nil
 func (e *DummyEnforcer) GetAllNamedSubjects(ptype string) []string {
 	return nil
 }
 
+// GetAllObjects returns nil
 func (e *DummyEnforcer) GetAllObjects() []string {
 	return nil
 }
 
+// GetAllNamedObjects returns nil
 func (e *DummyEnforcer) GetAllNamedObjects(ptype string) []string {
 	return nil
 }
 
+// GetAllActions returns nil
 func (e *DummyEnforcer) GetAllActions() []string {
 	return nil
 }
 
+// GetAllNamedActions returns nil
 func (e *DummyEnforcer) GetAllNamedActions(ptype string) []string {
 	return nil
 }
 
+// GetAllRoles returns nil
 func (e *DummyEnforcer) GetAllRoles() []string {
 	return nil
 }
 
+// GetAllNamedRoles returns nil
 func (e *DummyEnforcer) GetAllNamedRoles(ptype string) []string {
 	return nil
 }
 
+// GetPolicy returns nil
 func (e *DummyEnforcer) GetPolicy() [][]string {
 	return nil
 }
 
+// GetFilteredPolicy returns nil
 func (e *DummyEnforcer) GetFilteredPolicy(fieldIndex int, fieldValues ...string) [][]string {
 	return nil
 }
 
+// GetNamedPolicy returns nil
 func (e *DummyEnforcer) GetNamedPolicy(ptype string) [][]string {
 	return nil
 }
 
+// GetFilteredNamedPolicy returns nil
 func (e *DummyEnforcer) GetFilteredNamedPolicy(ptype string, fieldIndex int, fieldValues ...string) [][]string {
 	return nil
 }
 
+// GetGroupingPolicy returns nil
 func (e *DummyEnforcer) GetGroupingPolicy() [][]string {
 	return nil
 }
 
+// GetFilteredGroupingPolicy returns nil
 func (e *DummyEnforcer) GetFilteredGroupingPolicy(fieldIndex int, fieldValues ...string) [][]string {
 	return nil
 }
 
+// GetNamedGroupingPolicy returns nil
 func (e *DummyEnforcer) GetNamedGroupingPolicy(ptype string) [][]string {
 	return nil
 }
 
+// GetFilteredNamedGroupingPolicy returns nil
 func (e *DummyEnforcer) GetFilteredNamedGroupingPolicy(ptype string, fieldIndex int, fieldValues ...string) [][]string {
 	return nil
 }
 
+// HasPolicy returns false
 func (e *DummyEnforcer) HasPolicy(params ...interface{}) bool {
 	return false
 }
 
+// HasNamedPolicy returns false
 func (e *DummyEnforcer) HasNamedPolicy(ptype string, params ...interface{}) bool {
 	return false
 }
 
+// AddPolicy returns false and ErrorUnsupported
 func (e *DummyEnforcer) AddPolicy(params ...interface{}) (bool, error) {
 	return false, ErrorUnsupported
 }
 
+// AddNamedPolicy returns false and ErrorUnsupported
 func (e *DummyEnforcer) AddNamedPolicy(ptype string, params ...interface{}) (bool, error) {
 	return false, ErrorUnsupported
 }
 
+// RemovePolicy returns false and ErrorUnsupported
 func (e *DummyEnforcer) RemovePolicy(params ...interface{}) (bool, error) {
 	return false, ErrorUnsupported
 }
 
+// RemoveFilteredPolicy returns false and ErrorUnsupported
 func (e *DummyEnforcer) RemoveFilteredPolicy(fieldIndex int, fieldValues ...string) (bool, error) {
 	return false, ErrorUnsupported
 }
 
+// RemoveNamedPolicy returns false and ErrorUnsupported
 func (e *DummyEnforcer) RemoveNamedPolicy(ptype string, params ...interface{}) (bool, error) {
 	return false, ErrorUnsupported
 }
 
+// RemoveFilteredNamedPolicy returns false and ErrorUnsupported
 func (e *DummyEnforcer) RemoveFilteredNamedPolicy(ptype string, fieldIndex int, fieldValues ...string) (bool, error) {
 	return false, ErrorUnsupported
 }
 
+// HasGroupingPolicy returns false
 func (e *DummyEnforcer) HasGroupingPolicy(params ...interface{}) bool {
 	return false
 }
 
+// HasNamedGroupingPolicy returns false
 func (e *DummyEnforcer) HasNamedGroupingPolicy(ptype string, params ...interface{}) bool {
 	return false
 }
 
+// AddGroupingPolicy returns false and ErrorUnsupported
 func (e *DummyEnforcer) AddGroupingPolicy(params ...interface{}) (bool, error) {
 	return false, ErrorUnsupported
 }
 
+// AddNamedGroupingPolicy returns false and ErrorUnsupported
 func (e *DummyEnforcer) AddNamedGroupingPolicy(ptype string, params ...interface{}) (bool, error) {
 	return false, ErrorUnsupported
 }
 
+// RemoveGroupingPolicy returns false and ErrorUnsupported
 func (e *DummyEnforcer) RemoveGroupingPolicy(params ...interface{}) (bool, error) {
 	return false, ErrorUnsupported
 }
 
+// RemoveFilteredGroupingPolicy returns false and ErrorUnsupported
 func (e *DummyEnforcer) RemoveFilteredGroupingPolicy(fieldIndex int, fieldValues ...string) (bool, error) {
 	return false, ErrorUnsupported
 }
 
+// RemoveNamedGroupingPolicy returns false and ErrorUnsupported
 func (e *DummyEnforcer) RemoveNamedGroupingPolicy(ptype string, params ...interface{}) (bool, error) {
 	return false, ErrorUnsupported
 }
 
+// RemoveFilteredNamedGroupingPolicy returns false and ErrorUnsupported
 func (e *DummyEnforcer) RemoveFilteredNamedGroupingPolicy(ptype string, fieldIndex int, fieldValues ...string) (bool, error) {
 	return false, ErrorUnsupported
 }
 
+// AddFunction does nothing
 func (e *DummyEnforcer) AddFunction(name string, function govaluate.ExpressionFunction) {
 	return
 }

--- a/enforcer_interface.go
+++ b/enforcer_interface.go
@@ -104,6 +104,9 @@ type (
 		AddFunction(name string, function func(args ...interface{}) (interface{}, error))
 	}
 
+	// BasicEnforcer is the interface that describes the minimal set of functions required for an enforcer
+	//
+	// An object implements BasicEnforcer to enable it to be used as a wrapper around Enforcer.
 	BasicEnforcer interface {
 		InitWithFile(modelPath string, policyPath string) error
 		InitWithAdapter(modelPath string, adapter persist.Adapter) error
@@ -132,6 +135,10 @@ type (
 		GetParentEnforcer() BasicEnforcer
 	}
 
+	// APIEnforcer is the interface which provides the management and RBAC API functions
+	//
+	// Enforcer wrappers must implement this interface in order to expose the RBAC and
+	// management APIs from lower level wrappers or the root Enforcer.
 	APIEnforcer interface {
 		GetRolesForUser(name string) ([]string, error)
 		GetUsersForRole(name string) ([]string, error)
@@ -190,12 +197,14 @@ type (
 		AddFunction(name string, function govaluate.ExpressionFunction)
 	}
 
+	// FullEnforcer is the interface which describes the full featured Enforcer interface
 	FullEnforcer interface {
 		BasicEnforcer
 		APIEnforcer
 	}
 )
 
+// GetRootEnforcer locates and returns the root instance of Enforcer from a arbitrarily wrapped instance
 func GetRootEnforcer(e BasicEnforcer) *Enforcer {
 	for {
 		if ne := e.GetParentEnforcer(); ne != nil {

--- a/enforcer_interface.go
+++ b/enforcer_interface.go
@@ -15,88 +15,193 @@
 package casbin
 
 import (
+	"github.com/Knetic/govaluate"
+
 	"github.com/casbin/casbin/v2/effect"
 	"github.com/casbin/casbin/v2/model"
 	"github.com/casbin/casbin/v2/persist"
 	"github.com/casbin/casbin/v2/rbac"
 )
 
-type IEnforcer interface {
-	/* Enforcer API */
-	InitWithFile(modelPath string, policyPath string)
-	InitWithAdapter(modelPath string, adapter persist.Adapter)
-	InitWithModelAndAdapter(m model.Model, adapter persist.Adapter)
-	LoadModel()
-	GetModel() model.Model
-	SetModel(m model.Model)
-	GetAdapter() persist.Adapter
-	SetAdapter(adapter persist.Adapter)
-	SetWatcher(watcher persist.Watcher)
-	SetRoleManager(rm rbac.RoleManager)
-	SetEffector(eft effect.Effector)
-	ClearPolicy()
-	LoadPolicy() error
-	LoadFilteredPolicy(filter interface{}) error
-	IsFiltered() bool
-	SavePolicy() error
-	EnableEnforce(enable bool)
-	EnableLog(enable bool)
-	EnableAutoSave(autoSave bool)
-	EnableAutoBuildRoleLinks(autoBuildRoleLinks bool)
-	BuildRoleLinks()
-	Enforce(rvals ...interface{}) bool
+type (
+	IEnforcer interface {
+		/* Enforcer API */
+		InitWithFile(modelPath string, policyPath string) error
+		InitWithAdapter(modelPath string, adapter persist.Adapter) error
+		InitWithModelAndAdapter(m model.Model, adapter persist.Adapter) error
+		LoadModel() error
+		GetModel() model.Model
+		SetModel(m model.Model)
+		GetAdapter() persist.Adapter
+		SetAdapter(adapter persist.Adapter)
+		SetWatcher(watcher persist.Watcher)
+		SetRoleManager(rm rbac.RoleManager)
+		SetEffector(eft effect.Effector)
+		ClearPolicy()
+		LoadPolicy() error
+		LoadFilteredPolicy(filter interface{}) error
+		IsFiltered() bool
+		SavePolicy() error
+		EnableEnforce(enable bool)
+		EnableLog(enable bool)
+		EnableAutoSave(autoSave bool)
+		EnableAutoBuildRoleLinks(autoBuildRoleLinks bool)
+		BuildRoleLinks()
+		Enforce(rvals ...interface{}) bool
 
-	/* RBAC API */
-	GetRolesForUser(name string) ([]string, error)
-	GetUsersForRole(name string) ([]string, error)
-	HasRoleForUser(name string, role string) (bool, error)
-	AddRoleForUser(user string, role string) bool
-	AddPermissionForUser(user string, permission ...string) bool
-	DeletePermissionForUser(user string, permission ...string) bool
-	DeletePermissionsForUser(user string) bool
-	GetPermissionsForUser(user string) [][]string
-	HasPermissionForUser(user string, permission ...string) bool
-	GetImplicitRolesForUser(name string, domain ...string) []string
-	GetImplicitPermissionsForUser(user string, domain ...string) [][]string
-	GetImplicitUsersForPermission(permission ...string) []string
-	DeleteRoleForUser(user string, role string) bool
-	DeleteRolesForUser(user string) bool
-	DeleteUser(user string) bool
-	DeleteRole(role string)
-	DeletePermission(permission ...string) bool
+		/* RBAC API */
+		GetRolesForUser(name string) ([]string, error)
+		GetUsersForRole(name string) ([]string, error)
+		HasRoleForUser(name string, role string) (bool, error)
+		AddRoleForUser(user string, role string) bool
+		AddPermissionForUser(user string, permission ...string) bool
+		DeletePermissionForUser(user string, permission ...string) bool
+		DeletePermissionsForUser(user string) bool
+		GetPermissionsForUser(user string) [][]string
+		HasPermissionForUser(user string, permission ...string) bool
+		GetImplicitRolesForUser(name string, domain ...string) []string
+		GetImplicitPermissionsForUser(user string, domain ...string) [][]string
+		GetImplicitUsersForPermission(permission ...string) []string
+		DeleteRoleForUser(user string, role string) bool
+		DeleteRolesForUser(user string) bool
+		DeleteUser(user string) bool
+		DeleteRole(role string)
+		DeletePermission(permission ...string) bool
 
-	/* Management API */
-	GetAllSubjects() []string
-	GetAllNamedSubjects(ptype string) []string
-	GetAllObjects() []string
-	GetAllNamedObjects(ptype string) []string
-	GetAllActions() []string
-	GetAllNamedActions(ptype string) []string
-	GetAllRoles() []string
-	GetAllNamedRoles(ptype string) []string
-	GetPolicy() [][]string
-	GetFilteredPolicy(fieldIndex int, fieldValues ...string) [][]string
-	GetNamedPolicy(ptype string) [][]string
-	GetFilteredNamedPolicy(ptype string, fieldIndex int, fieldValues ...string) [][]string
-	GetGroupingPolicy() [][]string
-	GetFilteredGroupingPolicy(fieldIndex int, fieldValues ...string) [][]string
-	GetNamedGroupingPolicy(ptype string) [][]string
-	GetFilteredNamedGroupingPolicy(ptype string, fieldIndex int, fieldValues ...string) [][]string
-	HasPolicy(params ...interface{}) bool
-	HasNamedPolicy(ptype string, params ...interface{}) bool
-	AddPolicy(params ...interface{}) bool
-	AddNamedPolicy(ptype string, params ...interface{}) bool
-	RemovePolicy(params ...interface{}) bool
-	RemoveFilteredPolicy(fieldIndex int, fieldValues ...string) bool
-	RemoveNamedPolicy(ptype string, params ...interface{}) bool
-	RemoveFilteredNamedPolicy(ptype string, fieldIndex int, fieldValues ...string) bool
-	HasGroupingPolicy(params ...interface{}) bool
-	HasNamedGroupingPolicy(ptype string, params ...interface{}) bool
-	AddGroupingPolicy(params ...interface{}) bool
-	AddNamedGroupingPolicy(ptype string, params ...interface{}) bool
-	RemoveGroupingPolicy(params ...interface{}) bool
-	RemoveFilteredGroupingPolicy(fieldIndex int, fieldValues ...string) bool
-	RemoveNamedGroupingPolicy(ptype string, params ...interface{}) bool
-	RemoveFilteredNamedGroupingPolicy(ptype string, fieldIndex int, fieldValues ...string) bool
-	AddFunction(name string, function func(args ...interface{}) (interface{}, error))
+		/* Management API */
+		GetAllSubjects() []string
+		GetAllNamedSubjects(ptype string) []string
+		GetAllObjects() []string
+		GetAllNamedObjects(ptype string) []string
+		GetAllActions() []string
+		GetAllNamedActions(ptype string) []string
+		GetAllRoles() []string
+		GetAllNamedRoles(ptype string) []string
+		GetPolicy() [][]string
+		GetFilteredPolicy(fieldIndex int, fieldValues ...string) [][]string
+		GetNamedPolicy(ptype string) [][]string
+		GetFilteredNamedPolicy(ptype string, fieldIndex int, fieldValues ...string) [][]string
+		GetGroupingPolicy() [][]string
+		GetFilteredGroupingPolicy(fieldIndex int, fieldValues ...string) [][]string
+		GetNamedGroupingPolicy(ptype string) [][]string
+		GetFilteredNamedGroupingPolicy(ptype string, fieldIndex int, fieldValues ...string) [][]string
+		HasPolicy(params ...interface{}) bool
+		HasNamedPolicy(ptype string, params ...interface{}) bool
+		AddPolicy(params ...interface{}) bool
+		AddNamedPolicy(ptype string, params ...interface{}) bool
+		RemovePolicy(params ...interface{}) bool
+		RemoveFilteredPolicy(fieldIndex int, fieldValues ...string) bool
+		RemoveNamedPolicy(ptype string, params ...interface{}) bool
+		RemoveFilteredNamedPolicy(ptype string, fieldIndex int, fieldValues ...string) bool
+		HasGroupingPolicy(params ...interface{}) bool
+		HasNamedGroupingPolicy(ptype string, params ...interface{}) bool
+		AddGroupingPolicy(params ...interface{}) bool
+		AddNamedGroupingPolicy(ptype string, params ...interface{}) bool
+		RemoveGroupingPolicy(params ...interface{}) bool
+		RemoveFilteredGroupingPolicy(fieldIndex int, fieldValues ...string) bool
+		RemoveNamedGroupingPolicy(ptype string, params ...interface{}) bool
+		RemoveFilteredNamedGroupingPolicy(ptype string, fieldIndex int, fieldValues ...string) bool
+		AddFunction(name string, function func(args ...interface{}) (interface{}, error))
+	}
+
+	BasicEnforcer interface {
+		InitWithFile(modelPath string, policyPath string) error
+		InitWithAdapter(modelPath string, adapter persist.Adapter) error
+		InitWithModelAndAdapter(m model.Model, adapter persist.Adapter) error
+		LoadModel() error
+		GetModel() model.Model
+		SetModel(m model.Model)
+		GetAdapter() persist.Adapter
+		SetAdapter(adapter persist.Adapter)
+		SetWatcher(watcher persist.Watcher) error
+		GetRoleManager() rbac.RoleManager
+		SetRoleManager(rm rbac.RoleManager)
+		SetEffector(eft effect.Effector)
+		ClearPolicy()
+		LoadPolicy() error
+		LoadFilteredPolicy(filter interface{}) error
+		IsFiltered() bool
+		SavePolicy() error
+		EnableEnforce(enable bool)
+		EnableLog(enable bool)
+		EnableAutoSave(autoSave bool)
+		EnableAutoBuildRoleLinks(autoBuildRoleLinks bool)
+		BuildRoleLinks() error
+		Enforce(rvals ...interface{}) (bool, error)
+		EnforceWithMatcher(matcher string, rvals ...interface{}) (bool, error)
+		GetParentEnforcer() BasicEnforcer
+	}
+
+	APIEnforcer interface {
+		GetRolesForUser(name string) ([]string, error)
+		GetUsersForRole(name string) ([]string, error)
+		HasRoleForUser(name string, role string) (bool, error)
+		AddRoleForUser(user string, role string) (bool, error)
+		DeleteRoleForUser(user string, role string) (bool, error)
+		DeleteRolesForUser(user string) (bool, error)
+		DeleteUser(user string) (bool, error)
+		DeleteRole(role string) (bool, error)
+		DeletePermission(permission ...string) (bool, error)
+		AddPermissionForUser(user string, permission ...string) (bool, error)
+		DeletePermissionForUser(user string, permission ...string) (bool, error)
+		DeletePermissionsForUser(user string) (bool, error)
+		GetPermissionsForUser(user string) [][]string
+		HasPermissionForUser(user string, permission ...string) bool
+		GetImplicitRolesForUser(name string, domain ...string) ([]string, error)
+		GetImplicitPermissionsForUser(user string, domain ...string) ([][]string, error)
+		GetImplicitUsersForPermission(permission ...string) ([]string, error)
+		GetUsersForRoleInDomain(name string, domain string) []string
+		GetRolesForUserInDomain(name string, domain string) []string
+		GetPermissionsForUserInDomain(user string, domain string) [][]string
+		AddRoleForUserInDomain(user string, role string, domain string) (bool, error)
+		DeleteRoleForUserInDomain(user string, role string, domain string) (bool, error)
+		GetAllSubjects() []string
+		GetAllNamedSubjects(ptype string) []string
+		GetAllObjects() []string
+		GetAllNamedObjects(ptype string) []string
+		GetAllActions() []string
+		GetAllNamedActions(ptype string) []string
+		GetAllRoles() []string
+		GetAllNamedRoles(ptype string) []string
+		GetPolicy() [][]string
+		GetFilteredPolicy(fieldIndex int, fieldValues ...string) [][]string
+		GetNamedPolicy(ptype string) [][]string
+		GetFilteredNamedPolicy(ptype string, fieldIndex int, fieldValues ...string) [][]string
+		GetGroupingPolicy() [][]string
+		GetFilteredGroupingPolicy(fieldIndex int, fieldValues ...string) [][]string
+		GetNamedGroupingPolicy(ptype string) [][]string
+		GetFilteredNamedGroupingPolicy(ptype string, fieldIndex int, fieldValues ...string) [][]string
+		HasPolicy(params ...interface{}) bool
+		HasNamedPolicy(ptype string, params ...interface{}) bool
+		AddPolicy(params ...interface{}) (bool, error)
+		AddNamedPolicy(ptype string, params ...interface{}) (bool, error)
+		RemovePolicy(params ...interface{}) (bool, error)
+		RemoveFilteredPolicy(fieldIndex int, fieldValues ...string) (bool, error)
+		RemoveNamedPolicy(ptype string, params ...interface{}) (bool, error)
+		RemoveFilteredNamedPolicy(ptype string, fieldIndex int, fieldValues ...string) (bool, error)
+		HasGroupingPolicy(params ...interface{}) bool
+		HasNamedGroupingPolicy(ptype string, params ...interface{}) bool
+		AddGroupingPolicy(params ...interface{}) (bool, error)
+		AddNamedGroupingPolicy(ptype string, params ...interface{}) (bool, error)
+		RemoveGroupingPolicy(params ...interface{}) (bool, error)
+		RemoveFilteredGroupingPolicy(fieldIndex int, fieldValues ...string) (bool, error)
+		RemoveNamedGroupingPolicy(ptype string, params ...interface{}) (bool, error)
+		RemoveFilteredNamedGroupingPolicy(ptype string, fieldIndex int, fieldValues ...string) (bool, error)
+		AddFunction(name string, function govaluate.ExpressionFunction)
+	}
+
+	FullEnforcer interface {
+		BasicEnforcer
+		APIEnforcer
+	}
+)
+
+func GetRootEnforcer(e BasicEnforcer) *Enforcer {
+	for {
+		if ne := e.GetParentEnforcer(); ne != nil {
+			e = ne
+		} else {
+			return e.(*Enforcer)
+		}
+	}
 }

--- a/enforcer_synced.go
+++ b/enforcer_synced.go
@@ -20,27 +20,189 @@ import (
 	"time"
 
 	"github.com/Knetic/govaluate"
+
+	"github.com/casbin/casbin/v2/effect"
+	"github.com/casbin/casbin/v2/model"
 	"github.com/casbin/casbin/v2/persist"
+	"github.com/casbin/casbin/v2/rbac"
 )
 
 // SyncedEnforcer wraps Enforcer and provides synchronized access
 type SyncedEnforcer struct {
-	*Enforcer
+	base     BasicEnforcer
+	api      APIEnforcer
 	m        sync.RWMutex
 	autoLoad bool
+	watcher  persist.Watcher
 }
 
 // NewSyncedEnforcer creates a synchronized enforcer via file or DB.
 func NewSyncedEnforcer(params ...interface{}) (*SyncedEnforcer, error) {
 	e := &SyncedEnforcer{}
-	var err error
-	e.Enforcer, err = NewEnforcer(params...)
-	if err != nil {
-		return nil, err
+	if len(params) == 1 {
+		if parent, ok := params[0].(FullEnforcer); ok {
+			e.base = parent
+			e.api = parent
+		} else if parent, ok := params[0].(BasicEnforcer); ok {
+			e.base = parent
+			e.api = &DummyEnforcer{}
+		}
+	}
+
+	if e.base == nil {
+		ef, err := NewEnforcer(params...)
+		if err != nil {
+			return nil, err
+		}
+		e.base = ef
+		e.api = ef
 	}
 
 	e.autoLoad = false
 	return e, nil
+}
+
+func (e *SyncedEnforcer) GetParentEnforcer() BasicEnforcer {
+	return e.base
+}
+
+func (e *SyncedEnforcer) InitWithFile(modelPath string, policyPath string) error {
+	e.m.Lock()
+	defer e.m.Unlock()
+	return e.base.InitWithFile(modelPath, policyPath)
+}
+
+func (e *SyncedEnforcer) InitWithAdapter(modelPath string, adapter persist.Adapter) error {
+	e.m.Lock()
+	defer e.m.Unlock()
+	return e.base.InitWithAdapter(modelPath, adapter)
+}
+
+func (e *SyncedEnforcer) InitWithModelAndAdapter(m model.Model, adapter persist.Adapter) error {
+	e.m.Lock()
+	defer e.m.Unlock()
+	return e.base.InitWithModelAndAdapter(m, adapter)
+}
+
+func (e *SyncedEnforcer) LoadModel() error {
+	e.m.Lock()
+	defer e.m.Unlock()
+	return e.base.LoadModel()
+}
+
+func (e *SyncedEnforcer) GetModel() model.Model {
+	return e.base.GetModel()
+}
+
+func (e *SyncedEnforcer) SetModel(m model.Model) {
+	e.m.Lock()
+	defer e.m.Unlock()
+	e.base.SetModel(m)
+}
+
+func (e *SyncedEnforcer) GetAdapter() persist.Adapter {
+	return e.base.GetAdapter()
+}
+
+func (e *SyncedEnforcer) SetAdapter(adapter persist.Adapter) {
+	e.m.Lock()
+	defer e.m.Unlock()
+	e.base.SetAdapter(adapter)
+}
+
+// SetWatcher sets the current watcher.
+func (e *SyncedEnforcer) SetWatcher(watcher persist.Watcher) error {
+	e.watcher = watcher
+	return watcher.SetUpdateCallback(func(string) { e.LoadPolicy() })
+}
+
+func (e *SyncedEnforcer) GetRoleManager() rbac.RoleManager {
+	return e.base.GetRoleManager()
+}
+
+func (e *SyncedEnforcer) SetRoleManager(rm rbac.RoleManager) {
+	e.m.Lock()
+	defer e.m.Unlock()
+	e.base.SetRoleManager(rm)
+}
+
+func (e *SyncedEnforcer) SetEffector(eft effect.Effector) {
+	e.m.Lock()
+	defer e.m.Unlock()
+	e.base.SetEffector(eft)
+}
+
+// ClearPolicy clears all policy.
+func (e *SyncedEnforcer) ClearPolicy() {
+	e.m.Lock()
+	defer e.m.Unlock()
+	e.base.ClearPolicy()
+}
+
+// LoadPolicy reloads the policy from file/database.
+func (e *SyncedEnforcer) LoadPolicy() error {
+	e.m.Lock()
+	defer e.m.Unlock()
+	return e.base.LoadPolicy()
+}
+
+func (e *SyncedEnforcer) LoadFilteredPolicy(filter interface{}) error {
+	e.m.Lock()
+	defer e.m.Unlock()
+	return e.base.LoadFilteredPolicy(filter)
+}
+
+func (e *SyncedEnforcer) IsFiltered() bool {
+	return e.base.IsFiltered()
+}
+
+// SavePolicy saves the current policy (usually after changed with Casbin API) back to file/database.
+func (e *SyncedEnforcer) SavePolicy() error {
+	e.m.RLock()
+	defer e.m.RUnlock()
+	if err := e.base.SavePolicy(); err != nil {
+		return err
+	}
+	if e.watcher != nil {
+		return e.watcher.Update()
+	}
+	return nil
+}
+
+func (e *SyncedEnforcer) EnableEnforce(enable bool) {
+	e.base.EnableEnforce(enable)
+}
+
+func (e *SyncedEnforcer) EnableLog(enable bool) {
+	e.base.EnableLog(enable)
+}
+
+func (e *SyncedEnforcer) EnableAutoSave(autoSave bool) {
+	e.base.EnableAutoSave(autoSave)
+}
+
+func (e *SyncedEnforcer) EnableAutoBuildRoleLinks(autoBuildRoleLinks bool) {
+	e.base.EnableAutoBuildRoleLinks(autoBuildRoleLinks)
+}
+
+// BuildRoleLinks manually rebuild the role inheritance relations.
+func (e *SyncedEnforcer) BuildRoleLinks() error {
+	e.m.RLock()
+	defer e.m.RUnlock()
+	return e.base.BuildRoleLinks()
+}
+
+// Enforce decides whether a "subject" can access a "object" with the operation "action", input parameters are usually: (sub, obj, act).
+func (e *SyncedEnforcer) Enforce(rvals ...interface{}) (bool, error) {
+	e.m.Lock()
+	defer e.m.Unlock()
+	return e.base.Enforce(rvals...)
+}
+
+func (e *SyncedEnforcer) EnforceWithMatcher(matcher string, rvals ...interface{}) (bool, error) {
+	e.m.Lock()
+	defer e.m.Unlock()
+	return e.base.EnforceWithMatcher(matcher, rvals)
 }
 
 // StartAutoLoadPolicy starts a go routine that will every specified duration call LoadPolicy
@@ -70,171 +232,130 @@ func (e *SyncedEnforcer) StopAutoLoadPolicy() {
 	e.autoLoad = false
 }
 
-// SetWatcher sets the current watcher.
-func (e *SyncedEnforcer) SetWatcher(watcher persist.Watcher) error {
-	e.watcher = watcher
-	return watcher.SetUpdateCallback(func(string) { e.LoadPolicy() })
-}
-
-// ClearPolicy clears all policy.
-func (e *SyncedEnforcer) ClearPolicy() {
-	e.m.Lock()
-	defer e.m.Unlock()
-	e.Enforcer.ClearPolicy()
-}
-
-// LoadPolicy reloads the policy from file/database.
-func (e *SyncedEnforcer) LoadPolicy() error {
-	e.m.Lock()
-	defer e.m.Unlock()
-	return e.Enforcer.LoadPolicy()
-}
-
-// SavePolicy saves the current policy (usually after changed with Casbin API) back to file/database.
-func (e *SyncedEnforcer) SavePolicy() error {
-	e.m.RLock()
-	defer e.m.RUnlock()
-	return e.Enforcer.SavePolicy()
-}
-
-// BuildRoleLinks manually rebuild the role inheritance relations.
-func (e *SyncedEnforcer) BuildRoleLinks() error {
-	e.m.RLock()
-	defer e.m.RUnlock()
-	return e.Enforcer.BuildRoleLinks()
-}
-
-// Enforce decides whether a "subject" can access a "object" with the operation "action", input parameters are usually: (sub, obj, act).
-func (e *SyncedEnforcer) Enforce(rvals ...interface{}) (bool, error) {
-	e.m.Lock()
-	defer e.m.Unlock()
-	return e.Enforcer.Enforce(rvals...)
-}
-
 // GetAllSubjects gets the list of subjects that show up in the current policy.
 func (e *SyncedEnforcer) GetAllSubjects() []string {
 	e.m.RLock()
 	defer e.m.RUnlock()
-	return e.Enforcer.GetAllSubjects()
+	return e.api.GetAllSubjects()
 }
 
 // GetAllNamedSubjects gets the list of subjects that show up in the current named policy.
 func (e *SyncedEnforcer) GetAllNamedSubjects(ptype string) []string {
 	e.m.RLock()
 	defer e.m.RUnlock()
-	return e.Enforcer.GetAllNamedSubjects(ptype)
+	return e.api.GetAllNamedSubjects(ptype)
 }
 
 // GetAllObjects gets the list of objects that show up in the current policy.
 func (e *SyncedEnforcer) GetAllObjects() []string {
 	e.m.RLock()
 	defer e.m.RUnlock()
-	return e.Enforcer.GetAllObjects()
+	return e.api.GetAllObjects()
 }
 
 // GetAllNamedObjects gets the list of objects that show up in the current named policy.
 func (e *SyncedEnforcer) GetAllNamedObjects(ptype string) []string {
 	e.m.RLock()
 	defer e.m.RUnlock()
-	return e.Enforcer.GetAllNamedObjects(ptype)
+	return e.api.GetAllNamedObjects(ptype)
 }
 
 // GetAllActions gets the list of actions that show up in the current policy.
 func (e *SyncedEnforcer) GetAllActions() []string {
 	e.m.RLock()
 	defer e.m.RUnlock()
-	return e.Enforcer.GetAllActions()
+	return e.api.GetAllActions()
 }
 
 // GetAllNamedActions gets the list of actions that show up in the current named policy.
 func (e *SyncedEnforcer) GetAllNamedActions(ptype string) []string {
 	e.m.RLock()
 	defer e.m.RUnlock()
-	return e.Enforcer.GetAllNamedActions(ptype)
+	return e.api.GetAllNamedActions(ptype)
 }
 
 // GetAllRoles gets the list of roles that show up in the current policy.
 func (e *SyncedEnforcer) GetAllRoles() []string {
 	e.m.RLock()
 	defer e.m.RUnlock()
-	return e.Enforcer.GetAllRoles()
+	return e.api.GetAllRoles()
 }
 
 // GetAllNamedRoles gets the list of roles that show up in the current named policy.
 func (e *SyncedEnforcer) GetAllNamedRoles(ptype string) []string {
 	e.m.RLock()
 	defer e.m.RUnlock()
-	return e.Enforcer.GetAllNamedRoles(ptype)
+	return e.api.GetAllNamedRoles(ptype)
 }
 
 // GetPolicy gets all the authorization rules in the policy.
 func (e *SyncedEnforcer) GetPolicy() [][]string {
 	e.m.RLock()
 	defer e.m.RUnlock()
-	return e.Enforcer.GetPolicy()
+	return e.api.GetPolicy()
 }
 
 // GetFilteredPolicy gets all the authorization rules in the policy, field filters can be specified.
 func (e *SyncedEnforcer) GetFilteredPolicy(fieldIndex int, fieldValues ...string) [][]string {
 	e.m.RLock()
 	defer e.m.RUnlock()
-	return e.Enforcer.GetFilteredPolicy(fieldIndex, fieldValues...)
+	return e.api.GetFilteredPolicy(fieldIndex, fieldValues...)
 }
 
 // GetNamedPolicy gets all the authorization rules in the named policy.
 func (e *SyncedEnforcer) GetNamedPolicy(ptype string) [][]string {
 	e.m.RLock()
 	defer e.m.RUnlock()
-	return e.Enforcer.GetNamedPolicy(ptype)
+	return e.api.GetNamedPolicy(ptype)
 }
 
 // GetFilteredNamedPolicy gets all the authorization rules in the named policy, field filters can be specified.
 func (e *SyncedEnforcer) GetFilteredNamedPolicy(ptype string, fieldIndex int, fieldValues ...string) [][]string {
 	e.m.RLock()
 	defer e.m.RUnlock()
-	return e.Enforcer.GetFilteredNamedPolicy(ptype, fieldIndex, fieldValues...)
+	return e.api.GetFilteredNamedPolicy(ptype, fieldIndex, fieldValues...)
 }
 
 // GetGroupingPolicy gets all the role inheritance rules in the policy.
 func (e *SyncedEnforcer) GetGroupingPolicy() [][]string {
 	e.m.RLock()
 	defer e.m.RUnlock()
-	return e.Enforcer.GetGroupingPolicy()
+	return e.api.GetGroupingPolicy()
 }
 
 // GetFilteredGroupingPolicy gets all the role inheritance rules in the policy, field filters can be specified.
 func (e *SyncedEnforcer) GetFilteredGroupingPolicy(fieldIndex int, fieldValues ...string) [][]string {
 	e.m.RLock()
 	defer e.m.RUnlock()
-	return e.Enforcer.GetFilteredGroupingPolicy(fieldIndex, fieldValues...)
+	return e.api.GetFilteredGroupingPolicy(fieldIndex, fieldValues...)
 }
 
 // GetNamedGroupingPolicy gets all the role inheritance rules in the policy.
 func (e *SyncedEnforcer) GetNamedGroupingPolicy(ptype string) [][]string {
 	e.m.RLock()
 	defer e.m.RUnlock()
-	return e.Enforcer.GetNamedGroupingPolicy(ptype)
+	return e.api.GetNamedGroupingPolicy(ptype)
 }
 
 // GetFilteredNamedGroupingPolicy gets all the role inheritance rules in the policy, field filters can be specified.
 func (e *SyncedEnforcer) GetFilteredNamedGroupingPolicy(ptype string, fieldIndex int, fieldValues ...string) [][]string {
 	e.m.RLock()
 	defer e.m.RUnlock()
-	return e.Enforcer.GetFilteredNamedGroupingPolicy(ptype, fieldIndex, fieldValues...)
+	return e.api.GetFilteredNamedGroupingPolicy(ptype, fieldIndex, fieldValues...)
 }
 
 // HasPolicy determines whether an authorization rule exists.
 func (e *SyncedEnforcer) HasPolicy(params ...interface{}) bool {
 	e.m.RLock()
 	defer e.m.RUnlock()
-	return e.Enforcer.HasPolicy(params...)
+	return e.api.HasPolicy(params...)
 }
 
 // HasNamedPolicy determines whether a named authorization rule exists.
 func (e *SyncedEnforcer) HasNamedPolicy(ptype string, params ...interface{}) bool {
 	e.m.RLock()
 	defer e.m.RUnlock()
-	return e.Enforcer.HasNamedPolicy(ptype, params...)
+	return e.api.HasNamedPolicy(ptype, params...)
 }
 
 // AddPolicy adds an authorization rule to the current policy.
@@ -243,7 +364,7 @@ func (e *SyncedEnforcer) HasNamedPolicy(ptype string, params ...interface{}) boo
 func (e *SyncedEnforcer) AddPolicy(params ...interface{}) (bool, error) {
 	e.m.Lock()
 	defer e.m.Unlock()
-	return e.Enforcer.AddPolicy(params...)
+	return e.api.AddPolicy(params...)
 }
 
 // AddNamedPolicy adds an authorization rule to the current named policy.
@@ -252,49 +373,49 @@ func (e *SyncedEnforcer) AddPolicy(params ...interface{}) (bool, error) {
 func (e *SyncedEnforcer) AddNamedPolicy(ptype string, params ...interface{}) (bool, error) {
 	e.m.Lock()
 	defer e.m.Unlock()
-	return e.Enforcer.AddNamedPolicy(ptype, params...)
+	return e.api.AddNamedPolicy(ptype, params...)
 }
 
 // RemovePolicy removes an authorization rule from the current policy.
 func (e *SyncedEnforcer) RemovePolicy(params ...interface{}) (bool, error) {
 	e.m.Lock()
 	defer e.m.Unlock()
-	return e.Enforcer.RemovePolicy(params...)
+	return e.api.RemovePolicy(params...)
 }
 
 // RemoveFilteredPolicy removes an authorization rule from the current policy, field filters can be specified.
 func (e *SyncedEnforcer) RemoveFilteredPolicy(fieldIndex int, fieldValues ...string) (bool, error) {
 	e.m.Lock()
 	defer e.m.Unlock()
-	return e.Enforcer.RemoveFilteredPolicy(fieldIndex, fieldValues...)
+	return e.api.RemoveFilteredPolicy(fieldIndex, fieldValues...)
 }
 
 // RemoveNamedPolicy removes an authorization rule from the current named policy.
 func (e *SyncedEnforcer) RemoveNamedPolicy(ptype string, params ...interface{}) (bool, error) {
 	e.m.Lock()
 	defer e.m.Unlock()
-	return e.Enforcer.RemoveNamedPolicy(ptype, params...)
+	return e.api.RemoveNamedPolicy(ptype, params...)
 }
 
 // RemoveFilteredNamedPolicy removes an authorization rule from the current named policy, field filters can be specified.
 func (e *SyncedEnforcer) RemoveFilteredNamedPolicy(ptype string, fieldIndex int, fieldValues ...string) (bool, error) {
 	e.m.Lock()
 	defer e.m.Unlock()
-	return e.Enforcer.RemoveFilteredNamedPolicy(ptype, fieldIndex, fieldValues...)
+	return e.api.RemoveFilteredNamedPolicy(ptype, fieldIndex, fieldValues...)
 }
 
 // HasGroupingPolicy determines whether a role inheritance rule exists.
 func (e *SyncedEnforcer) HasGroupingPolicy(params ...interface{}) bool {
 	e.m.RLock()
 	defer e.m.RUnlock()
-	return e.Enforcer.HasGroupingPolicy(params...)
+	return e.api.HasGroupingPolicy(params...)
 }
 
 // HasNamedGroupingPolicy determines whether a named role inheritance rule exists.
 func (e *SyncedEnforcer) HasNamedGroupingPolicy(ptype string, params ...interface{}) bool {
 	e.m.RLock()
 	defer e.m.RUnlock()
-	return e.Enforcer.HasNamedGroupingPolicy(ptype, params...)
+	return e.api.HasNamedGroupingPolicy(ptype, params...)
 }
 
 // AddGroupingPolicy adds a role inheritance rule to the current policy.
@@ -303,7 +424,7 @@ func (e *SyncedEnforcer) HasNamedGroupingPolicy(ptype string, params ...interfac
 func (e *SyncedEnforcer) AddGroupingPolicy(params ...interface{}) (bool, error) {
 	e.m.Lock()
 	defer e.m.Unlock()
-	return e.Enforcer.AddGroupingPolicy(params...)
+	return e.api.AddGroupingPolicy(params...)
 }
 
 // AddNamedGroupingPolicy adds a named role inheritance rule to the current policy.
@@ -312,40 +433,58 @@ func (e *SyncedEnforcer) AddGroupingPolicy(params ...interface{}) (bool, error) 
 func (e *SyncedEnforcer) AddNamedGroupingPolicy(ptype string, params ...interface{}) (bool, error) {
 	e.m.Lock()
 	defer e.m.Unlock()
-	return e.Enforcer.AddNamedGroupingPolicy(ptype, params...)
+	return e.api.AddNamedGroupingPolicy(ptype, params...)
 }
 
 // RemoveGroupingPolicy removes a role inheritance rule from the current policy.
 func (e *SyncedEnforcer) RemoveGroupingPolicy(params ...interface{}) (bool, error) {
 	e.m.Lock()
 	defer e.m.Unlock()
-	return e.Enforcer.RemoveGroupingPolicy(params...)
+	return e.api.RemoveGroupingPolicy(params...)
 }
 
 // RemoveFilteredGroupingPolicy removes a role inheritance rule from the current policy, field filters can be specified.
 func (e *SyncedEnforcer) RemoveFilteredGroupingPolicy(fieldIndex int, fieldValues ...string) (bool, error) {
 	e.m.Lock()
 	defer e.m.Unlock()
-	return e.Enforcer.RemoveFilteredGroupingPolicy(fieldIndex, fieldValues...)
+	return e.api.RemoveFilteredGroupingPolicy(fieldIndex, fieldValues...)
 }
 
 // RemoveNamedGroupingPolicy removes a role inheritance rule from the current named policy.
 func (e *SyncedEnforcer) RemoveNamedGroupingPolicy(ptype string, params ...interface{}) (bool, error) {
 	e.m.Lock()
 	defer e.m.Unlock()
-	return e.Enforcer.RemoveNamedGroupingPolicy(ptype, params...)
+	return e.api.RemoveNamedGroupingPolicy(ptype, params...)
 }
 
 // RemoveFilteredNamedGroupingPolicy removes a role inheritance rule from the current named policy, field filters can be specified.
 func (e *SyncedEnforcer) RemoveFilteredNamedGroupingPolicy(ptype string, fieldIndex int, fieldValues ...string) (bool, error) {
 	e.m.Lock()
 	defer e.m.Unlock()
-	return e.Enforcer.RemoveFilteredNamedGroupingPolicy(ptype, fieldIndex, fieldValues...)
+	return e.api.RemoveFilteredNamedGroupingPolicy(ptype, fieldIndex, fieldValues...)
 }
 
 // AddFunction adds a customized function.
 func (e *SyncedEnforcer) AddFunction(name string, function govaluate.ExpressionFunction) {
 	e.m.Lock()
 	defer e.m.Unlock()
-	e.Enforcer.AddFunction(name, function)
+	e.api.AddFunction(name, function)
+}
+
+func (e *SyncedEnforcer) GetImplicitPermissionsForUser(user string, domain ...string) ([][]string, error) {
+	e.m.RLock()
+	defer e.m.RUnlock()
+	return e.api.GetImplicitPermissionsForUser(user, domain...)
+}
+
+func (e *SyncedEnforcer) GetImplicitRolesForUser(user string, domain ...string) ([]string, error) {
+	e.m.RLock()
+	defer e.m.RUnlock()
+	return e.api.GetImplicitRolesForUser(user, domain...)
+}
+
+func (e *SyncedEnforcer) GetImplicitUsersForPermission(permission ...string) ([]string, error) {
+	e.m.RLock()
+	defer e.m.RUnlock()
+	return e.api.GetImplicitUsersForPermission(permission...)
 }

--- a/enforcer_synced.go
+++ b/enforcer_synced.go
@@ -29,6 +29,7 @@ import (
 
 // SyncedEnforcer wraps Enforcer and provides synchronized access
 type SyncedEnforcer struct {
+	Enforcer *Enforcer
 	base     BasicEnforcer
 	api      APIEnforcer
 	m        sync.RWMutex
@@ -58,6 +59,7 @@ func NewSyncedEnforcer(params ...interface{}) (*SyncedEnforcer, error) {
 		e.api = ef
 	}
 
+	e.Enforcer = GetRootEnforcer(e.base)
 	e.autoLoad = false
 	return e, nil
 }

--- a/rbac_api_cached.go
+++ b/rbac_api_cached.go
@@ -1,0 +1,80 @@
+package casbin
+
+// GetRolesForUser gets the roles that a user has.
+func (e *CachedEnforcer) GetRolesForUser(name string) ([]string, error) {
+	return e.api.GetRolesForUser(name)
+}
+
+// GetUsersForRole gets the users that has a role.
+func (e *CachedEnforcer) GetUsersForRole(name string) ([]string, error) {
+	return e.api.GetUsersForRole(name)
+}
+
+// HasRoleForUser determines whether a user has a role.
+func (e *CachedEnforcer) HasRoleForUser(name string, role string) (bool, error) {
+	return e.api.HasRoleForUser(name, role)
+}
+
+// AddRoleForUser adds a role for a user.
+// Returns false if the user already has the role (aka not affected).
+func (e *CachedEnforcer) AddRoleForUser(user string, role string) (bool, error) {
+	return e.api.AddRoleForUser(user, role)
+}
+
+// DeleteRoleForUser deletes a role for a user.
+// Returns false if the user does not have the role (aka not affected).
+func (e *CachedEnforcer) DeleteRoleForUser(user string, role string) (bool, error) {
+	return e.api.DeleteRoleForUser(user, role)
+}
+
+// DeleteRolesForUser deletes all roles for a user.
+// Returns false if the user does not have any roles (aka not affected).
+func (e *CachedEnforcer) DeleteRolesForUser(user string) (bool, error) {
+	return e.api.DeleteRolesForUser(user)
+}
+
+// DeleteUser deletes a user.
+// Returns false if the user does not exist (aka not affected).
+func (e *CachedEnforcer) DeleteUser(user string) (bool, error) {
+	return e.api.DeleteUser(user)
+}
+
+// DeleteRole deletes a role.
+// Returns false if the role does not exist (aka not affected).
+func (e *CachedEnforcer) DeleteRole(role string) (bool, error) {
+	return e.api.DeleteRole(role)
+}
+
+// DeletePermission deletes a permission.
+// Returns false if the permission does not exist (aka not affected).
+func (e *CachedEnforcer) DeletePermission(permission ...string) (bool, error) {
+	return e.api.DeletePermission(permission...)
+}
+
+// AddPermissionForUser adds a permission for a user or role.
+// Returns false if the user or role already has the permission (aka not affected).
+func (e *CachedEnforcer) AddPermissionForUser(user string, permission ...string) (bool, error) {
+	return e.api.AddPermissionForUser(user, permission...)
+}
+
+// DeletePermissionForUser deletes a permission for a user or role.
+// Returns false if the user or role does not have the permission (aka not affected).
+func (e *CachedEnforcer) DeletePermissionForUser(user string, permission ...string) (bool, error) {
+	return e.api.DeletePermissionForUser(user, permission...)
+}
+
+// DeletePermissionsForUser deletes permissions for a user or role.
+// Returns false if the user or role does not have any permissions (aka not affected).
+func (e *CachedEnforcer) DeletePermissionsForUser(user string) (bool, error) {
+	return e.api.DeletePermissionsForUser(user)
+}
+
+// GetPermissionsForUser gets permissions for a user or role.
+func (e *CachedEnforcer) GetPermissionsForUser(user string) [][]string {
+	return e.api.GetPermissionsForUser(user)
+}
+
+// HasPermissionForUser determines whether a user has a permission.
+func (e *CachedEnforcer) HasPermissionForUser(user string, permission ...string) bool {
+	return e.api.HasPermissionForUser(user, permission...)
+}

--- a/rbac_api_synced.go
+++ b/rbac_api_synced.go
@@ -18,21 +18,21 @@ package casbin
 func (e *SyncedEnforcer) GetRolesForUser(name string) ([]string, error) {
 	e.m.RLock()
 	defer e.m.RUnlock()
-	return e.Enforcer.GetRolesForUser(name)
+	return e.api.GetRolesForUser(name)
 }
 
 // GetUsersForRole gets the users that has a role.
 func (e *SyncedEnforcer) GetUsersForRole(name string) ([]string, error) {
 	e.m.RLock()
 	defer e.m.RUnlock()
-	return e.Enforcer.GetUsersForRole(name)
+	return e.api.GetUsersForRole(name)
 }
 
 // HasRoleForUser determines whether a user has a role.
 func (e *SyncedEnforcer) HasRoleForUser(name string, role string) (bool, error) {
 	e.m.RLock()
 	defer e.m.RUnlock()
-	return e.Enforcer.HasRoleForUser(name, role)
+	return e.api.HasRoleForUser(name, role)
 }
 
 // AddRoleForUser adds a role for a user.
@@ -40,7 +40,7 @@ func (e *SyncedEnforcer) HasRoleForUser(name string, role string) (bool, error) 
 func (e *SyncedEnforcer) AddRoleForUser(user string, role string) (bool, error) {
 	e.m.Lock()
 	defer e.m.Unlock()
-	return e.Enforcer.AddRoleForUser(user, role)
+	return e.api.AddRoleForUser(user, role)
 }
 
 // DeleteRoleForUser deletes a role for a user.
@@ -48,7 +48,7 @@ func (e *SyncedEnforcer) AddRoleForUser(user string, role string) (bool, error) 
 func (e *SyncedEnforcer) DeleteRoleForUser(user string, role string) (bool, error) {
 	e.m.Lock()
 	defer e.m.Unlock()
-	return e.Enforcer.DeleteRoleForUser(user, role)
+	return e.api.DeleteRoleForUser(user, role)
 }
 
 // DeleteRolesForUser deletes all roles for a user.
@@ -56,7 +56,7 @@ func (e *SyncedEnforcer) DeleteRoleForUser(user string, role string) (bool, erro
 func (e *SyncedEnforcer) DeleteRolesForUser(user string) (bool, error) {
 	e.m.Lock()
 	defer e.m.Unlock()
-	return e.Enforcer.DeleteRolesForUser(user)
+	return e.api.DeleteRolesForUser(user)
 }
 
 // DeleteUser deletes a user.
@@ -64,7 +64,7 @@ func (e *SyncedEnforcer) DeleteRolesForUser(user string) (bool, error) {
 func (e *SyncedEnforcer) DeleteUser(user string) (bool, error) {
 	e.m.Lock()
 	defer e.m.Unlock()
-	return e.Enforcer.DeleteUser(user)
+	return e.api.DeleteUser(user)
 }
 
 // DeleteRole deletes a role.
@@ -72,7 +72,7 @@ func (e *SyncedEnforcer) DeleteUser(user string) (bool, error) {
 func (e *SyncedEnforcer) DeleteRole(role string) (bool, error) {
 	e.m.Lock()
 	defer e.m.Unlock()
-	return e.Enforcer.DeleteRole(role)
+	return e.api.DeleteRole(role)
 }
 
 // DeletePermission deletes a permission.
@@ -80,7 +80,7 @@ func (e *SyncedEnforcer) DeleteRole(role string) (bool, error) {
 func (e *SyncedEnforcer) DeletePermission(permission ...string) (bool, error) {
 	e.m.Lock()
 	defer e.m.Unlock()
-	return e.Enforcer.DeletePermission(permission...)
+	return e.api.DeletePermission(permission...)
 }
 
 // AddPermissionForUser adds a permission for a user or role.
@@ -88,7 +88,7 @@ func (e *SyncedEnforcer) DeletePermission(permission ...string) (bool, error) {
 func (e *SyncedEnforcer) AddPermissionForUser(user string, permission ...string) (bool, error) {
 	e.m.Lock()
 	defer e.m.Unlock()
-	return e.Enforcer.AddPermissionForUser(user, permission...)
+	return e.api.AddPermissionForUser(user, permission...)
 }
 
 // DeletePermissionForUser deletes a permission for a user or role.
@@ -96,7 +96,7 @@ func (e *SyncedEnforcer) AddPermissionForUser(user string, permission ...string)
 func (e *SyncedEnforcer) DeletePermissionForUser(user string, permission ...string) (bool, error) {
 	e.m.Lock()
 	defer e.m.Unlock()
-	return e.Enforcer.DeletePermissionForUser(user, permission...)
+	return e.api.DeletePermissionForUser(user, permission...)
 }
 
 // DeletePermissionsForUser deletes permissions for a user or role.
@@ -104,19 +104,19 @@ func (e *SyncedEnforcer) DeletePermissionForUser(user string, permission ...stri
 func (e *SyncedEnforcer) DeletePermissionsForUser(user string) (bool, error) {
 	e.m.Lock()
 	defer e.m.Unlock()
-	return e.Enforcer.DeletePermissionsForUser(user)
+	return e.api.DeletePermissionsForUser(user)
 }
 
 // GetPermissionsForUser gets permissions for a user or role.
 func (e *SyncedEnforcer) GetPermissionsForUser(user string) [][]string {
 	e.m.RLock()
 	defer e.m.RUnlock()
-	return e.Enforcer.GetPermissionsForUser(user)
+	return e.api.GetPermissionsForUser(user)
 }
 
 // HasPermissionForUser determines whether a user has a permission.
 func (e *SyncedEnforcer) HasPermissionForUser(user string, permission ...string) bool {
 	e.m.RLock()
 	defer e.m.RUnlock()
-	return e.Enforcer.HasPermissionForUser(user, permission...)
+	return e.api.HasPermissionForUser(user, permission...)
 }

--- a/rbac_api_with_domains_cached.go
+++ b/rbac_api_with_domains_cached.go
@@ -15,38 +15,28 @@
 package casbin
 
 // GetUsersForRoleInDomain gets the users that has a role inside a domain. Add by Gordon
-func (e *SyncedEnforcer) GetUsersForRoleInDomain(name string, domain string) []string {
-	e.m.Lock()
-	defer e.m.Unlock()
+func (e *CachedEnforcer) GetUsersForRoleInDomain(name string, domain string) []string {
 	return e.api.GetUsersForRoleInDomain(name, domain)
 }
 
 // GetRolesForUserInDomain gets the roles that a user has inside a domain.
-func (e *SyncedEnforcer) GetRolesForUserInDomain(name string, domain string) []string {
-	e.m.Lock()
-	defer e.m.Unlock()
+func (e *CachedEnforcer) GetRolesForUserInDomain(name string, domain string) []string {
 	return e.api.GetRolesForUserInDomain(name, domain)
 }
 
 // GetPermissionsForUserInDomain gets permissions for a user or role inside a domain.
-func (e *SyncedEnforcer) GetPermissionsForUserInDomain(user string, domain string) [][]string {
-	e.m.Lock()
-	defer e.m.Unlock()
+func (e *CachedEnforcer) GetPermissionsForUserInDomain(user string, domain string) [][]string {
 	return e.api.GetPermissionsForUserInDomain(user, domain)
 }
 
 // AddRoleForUserInDomain adds a role for a user inside a domain.
 // Returns false if the user already has the role (aka not affected).
-func (e *SyncedEnforcer) AddRoleForUserInDomain(user string, role string, domain string) (bool, error) {
-	e.m.Lock()
-	defer e.m.Unlock()
+func (e *CachedEnforcer) AddRoleForUserInDomain(user string, role string, domain string) (bool, error) {
 	return e.api.AddRoleForUserInDomain(user, role, domain)
 }
 
 // DeleteRoleForUserInDomain deletes a role for a user inside a domain.
 // Returns false if the user does not have the role (aka not affected).
-func (e *SyncedEnforcer) DeleteRoleForUserInDomain(user string, role string, domain string) (bool, error) {
-	e.m.Lock()
-	defer e.m.Unlock()
+func (e *CachedEnforcer) DeleteRoleForUserInDomain(user string, role string, domain string) (bool, error) {
 	return e.api.DeleteRoleForUserInDomain(user, role, domain)
 }

--- a/util/util.go
+++ b/util/util.go
@@ -20,14 +20,15 @@ import (
 	"strings"
 )
 
+var assertionRegex = regexp.MustCompile(`([| =)(&<>,+\-!*/])([rp])\.`)
+
 // EscapeAssertion escapes the dots in the assertion, because the expression evaluation doesn't support such variable names.
 func EscapeAssertion(s string) string {
 	//Replace the first dot, because it can't be recognized by the regexp.
-	if (strings.HasPrefix(s, "r") || strings.HasPrefix(s, "p")) {
-		s = strings.Replace(s, ".", "_",1)
+	if strings.HasPrefix(s, "r") || strings.HasPrefix(s, "p") {
+		s = strings.Replace(s, ".", "_", 1)
 	}
-	var regex = regexp.MustCompile(`(\|| |=|\)|\(|&|<|>|,|\+|-|!|\*|\/)(r|p)\.`)
-	s = regex.ReplaceAllStringFunc(s, func(m string) string {
+	s = assertionRegex.ReplaceAllStringFunc(s, func(m string) string {
 		return strings.Replace(m, ".", "_", 1)
 	})
 	return s


### PR DESCRIPTION
Hi,
I'm not sure if this is in line with your plans for the project but I had a need to make these changes as part of a larger project I am working on and thought I would submit a pull request in case they are useful to others.

The purpose of the changes was to generalise the Enforcer API into an interface definition. I split the interface into two parts for convenience, the BasicEnforcer and APIEnforcer.
BasicEnforcer defines the basic set of functions for an object to be considered a valid enforcer. APIEnforcer defines the full enforcer API set, including RBAC and Management functions.

The reason for the extraction of an interface was to allow me to chain different enforcers together. Specifically, I wanted to take advantage of the new cached enforcer as well as the synced enforcer at the same time.

Rather than just creating a custom enforcer inside out of the two existing ones I thought it would be better to make the enforcers chainable. That has allowed me to also create a custom Enforcer wrapper inside of a private repository to provide audit logging. Enabling caching, audit logging or any other feature someone might want to implement can now be achieved by chaining the relevant Enforcer implementations together.

I believe (unless I have made a mistake) that none of the changes are API breaking, and only add extra functionality.

I ran benchmarks with and without this chaining ability and there was no observable difference in performance, so I believe any effects are negligible. 

I also added some example code showing how you might wish to chain enforcer implementations together.

Finally, I added an extra method GetRootEnforcer which returns the underlying Enforcer instance at the end of the chain. This is to ensure a user can still access the largest feature set if implementations further up the chain do not implement the APIEnforcer interface. To make this function I added a function to the BasicEnforcer interface called GetParentEnforcer() which retrieves the next lower enforcer in the chain, with the root Enforcer implementation returning nil to indicate the end of the chain.

No worries if this is not the sort of thing you are looking for, I realise there are some significant changes, but thought I'd share just in case :) The Casbin project has proved incredibly useful for me and my company so I am incredibly grateful for all the hard work that has gone into it!