### PR TITLE
Resolve policy conflict

### DIFF
--- a/errors/rbac_errors.go
+++ b/errors/rbac_errors.go
@@ -21,4 +21,5 @@ var (
 	ERR_NAME_NOT_FOUND    = errors.New("error: name does not exist")
 	ERR_DOMAIN_PARAMETER  = errors.New("error: domain should be 1 parameter")
 	ERR_NAMES12_NOT_FOUND = errors.New("error: name1 or name2 does not exist")
+	ERR_POLICY_CONFLICTS  = errors.New("error: policy has exists")
 )

--- a/examples/rbac_with_pattern_policy.csv
+++ b/examples/rbac_with_pattern_policy.csv
@@ -10,7 +10,6 @@ g, /book/*, book_group
 g, cathy, /book/1/2/3/4/5
 g, cathy, pen_admin
 
-g2, /book/:id, book_group
 g2, /pen/:id, pen_group
 
 g2, /book2/{id}, book_group

--- a/rbac/default-role-manager/role_manager.go
+++ b/rbac/default-role-manager/role_manager.go
@@ -229,12 +229,12 @@ func (rm *RoleManager) PrintRoles() error {
 
 // CheckLoop check if there are policy conflicts
 func (rm *RoleManager) CheckLoop(role1 *Role, role2 *Role) bool {
-	if ok, _ := rm.HasLink(role1.name, role2.name); ok {
+	if ok, _ := rm.HasLink(role2.name, role1.name); ok {
 		return true
 	}
 
 	for _, role := range role1.roles {
-		if rm.CheckLoop(role2, role) {
+		if rm.CheckLoop(role, role2) {
 			return true
 		}
 	}

--- a/rbac/default-role-manager/role_manager_test.go
+++ b/rbac/default-role-manager/role_manager_test.go
@@ -241,7 +241,9 @@ func TestClear(t *testing.T) {
 
 func TestLoopRole(t *testing.T) {
 	rm := NewRoleManager(3)
+	testCheckLoop(t, rm, "g1", "g2", false)
 	testConflictRole(t, rm, "g1", "g2", true)
+	testCheckLoop(t, rm, "u2", "g1", false)
 	testConflictRole(t, rm, "u2", "g1", true)
 	testCheckLoop(t, rm, "u2", "g2", true)
 	testConflictRole(t, rm, "u2", "g2", false)
@@ -253,8 +255,11 @@ func TestLoopRole(t *testing.T) {
 	//               u2
 
 	rm.Clear()
+	testCheckLoop(t, rm, "g2", "g1", false)
 	testConflictRole(t, rm, "g2", "g1", true)
+	testCheckLoop(t, rm, "g3", "g1", false)
 	testConflictRole(t, rm, "g3", "g1", true)
+	testCheckLoop(t, rm, "u1", "g1", false)
 	testConflictRole(t, rm, "u1", "g1", true)
 	testCheckLoop(t, rm, "u1", "g3", true)
 	testConflictRole(t, rm, "u1", "g3", false)
@@ -266,8 +271,11 @@ func TestLoopRole(t *testing.T) {
 	//               u1
 
 	rm.Clear()
+	testCheckLoop(t, rm, "u2", "g1", false)
 	testConflictRole(t, rm, "u2", "g1", true)
+	testCheckLoop(t, rm, "u2", "g2", false)
 	testConflictRole(t, rm, "u2", "g2", true)
+	testCheckLoop(t, rm, "g1", "g2", false)
 	testConflictRole(t, rm, "g1", "g2", true)
 	// Current role inheritance tree:
 	//       g1   g2                  g1 - g2

--- a/rbac/default-role-manager/role_manager_test.go
+++ b/rbac/default-role-manager/role_manager_test.go
@@ -68,6 +68,14 @@ func testCheckLoop(t *testing.T, rm rbac.RoleManager, name1 string, name2 string
 		t.Errorf("%s < %s: %t, supposed to be %t", name1, name2, !res, res)
 	}
 }
+
+func testDeleteRole(t *testing.T, rm rbac.RoleManager, name1 string, name2 string) {
+	err := rm.DeleteLink(name1, name2)
+	if err != nil {
+		t.Errorf("%s < %s : %s, delete link wrong", name1, name2, err.Error())
+	}
+}
+
 func TestRole(t *testing.T) {
 	rm := NewRoleManager(3)
 	rm.AddLink("u1", "g1")
@@ -239,6 +247,40 @@ func TestClear(t *testing.T) {
 	testRole(t, rm, "u4", "g3", false)
 }
 
+func TestDeleteRole(t *testing.T) {
+	rm := NewRoleManager(3)
+	rm.AddLink("u1", "g1")
+	rm.AddLink("u2", "g1")
+	rm.AddLink("u3", "g2")
+	rm.AddLink("u4", "g2")
+	rm.AddLink("u4", "g3")
+	rm.AddLink("g1", "g3")
+
+	// Current role inheritance tree:
+	//             g3    g2
+	//            /  \  /  \
+	//          g1    u4    u3
+	//         /  \
+	//       u1    u2
+
+	testDeleteRole(t, rm, "g1", "g3")
+
+	// Current role inheritance tree:
+	//             g3    g2
+	//               \  /  \
+	//          g1    u4    u3
+	//         /  \
+	//       u1    u2
+
+	testDeleteRole(t, rm, "u4", "g3")
+
+	// Current role inheritance tree:
+	//             g3    g2
+	//                  /  \
+	//          g1    u4    u3
+	//         /  \
+	//       u1    u2
+}
 func TestLoopRole(t *testing.T) {
 	rm := NewRoleManager(3)
 	testCheckLoop(t, rm, "g1", "g2", false)


### PR DESCRIPTION
https://github.com/casbin/casbin/issues/338
I added some conflict detection and it will return an error if a loop occurs
in `examples/rbac_with_pattern_policy.csv`, the role inheritance tree like this
```
        bookgroup
             |   \
        /book/*   |
             |   /
           /book/:id
 ```

it has a loop，So I modified this file

Is the inheritance relationship more like a graph than a tree? Now this test is valid only if we first generate the relationship of the inherited. So if we add role like below, it cannot be detected

```
rm.AddLink(“u1”, "g1")
rm.AddLink(“u1”, "g2")
rm.AddLink(“g1”, "g2")
//       g1   g2                  g1 - g2
//         \   /          ->       \    /
//          u1                       u1
```

Do you think we should change the structure of role？like this
```
type Role struct {
	name  string
	childs []*Role
        parents []*Role
}
```

I want to try to avoid loops using minimal spanning tree
