### PR TITLE
ADD HasImplicitPermissionForUserInDomain() and HasImplicitPermissionForUser()

### DIFF
--- a/examples/basic_without_resources_policy.csv
+++ b/examples/basic_without_resources_policy.csv
@@ -1,2 +1,3 @@
 p, alice, read
 p, bob, write
+p, carol, read

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/casbin/casbin/v2
 
+go 1.14
+
 require github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible

--- a/rbac_api.go
+++ b/rbac_api.go
@@ -127,6 +127,26 @@ func (e *Enforcer) HasPermissionForUser(user string, permission ...string) bool 
 	return e.HasPolicy(util.JoinSlice(user, permission...))
 }
 
+// HasImplicitPermissionForUser determines whtether a user has a permission implicitly
+// If use model with domain, please call HasImplicitPermissionForUserInDomain
+func (e *Enforcer) HasImplicitPermissionForUser(user string, permission ...string) (bool, error) {
+  if users, err := e.GetImplicitRolesForUser(user); err != nil {
+    return false, err
+  } else {
+    return e.HasPermissionAmongUsers(users, permission...), nil
+  }
+}
+
+// HasPermissionInUsers will determines if one of the users has a permission
+func (e *Enforcer) HasPermissionAmongUsers(users []string, permission ...string) bool {
+  for _, user := range users {
+    if e.HasPermissionForUser(user, permission...) {
+      return true
+    }
+  }
+  return false
+}
+
 // GetImplicitRolesForUser gets implicit roles that a user has.
 // Compared to GetRolesForUser(), this function retrieves indirect roles besides direct roles.
 // For example:

--- a/rbac_api_with_domains.go
+++ b/rbac_api_with_domains.go
@@ -42,3 +42,24 @@ func (e *Enforcer) AddRoleForUserInDomain(user string, role string, domain strin
 func (e *Enforcer) DeleteRoleForUserInDomain(user string, role string, domain string) (bool, error) {
 	return e.RemoveGroupingPolicy(user, role, domain)
 }
+
+// HasImplicitPermissionForUserInDomain determines whether a user has a permission implicitly
+// Because we have no idea which param in permission is domain, user has to provide it manually
+func (e *Enforcer) HasImplicitPermissionForUserInDomain(user string, domain string, permission ...string) (bool, error) {
+  sameDomain := false
+  for _, param := range permission {
+    if domain == param {
+      sameDomain = true
+      break
+    }
+  }
+  if !sameDomain {
+    return false, nil
+  }
+  if users, err := e.GetImplicitRolesForUser(user, domain); err != nil {
+    return false, err
+  } else {
+    users = append(users, user)
+    return e.HasPermissionAmongUsers(users, permission...), nil
+  }
+}

--- a/rbac_api_with_domains_test.go
+++ b/rbac_api_with_domains_test.go
@@ -41,6 +41,16 @@ func testGetRolesInDomain(t *testing.T, e *Enforcer, name string, domain string,
 	}
 }
 
+func testHasImplicitPermissionForUserInDomain(t *testing.T, e *Enforcer, name string, domain string, permission []string, res bool) {
+	t.Helper()
+	myRes, _ := e.HasImplicitPermissionForUserInDomain(name, domain, permission...)
+	t.Log("Implicit Permission ", util.ArrayToString(permission), " for ", name, " under ", domain, ": ", myRes)
+
+	if res != myRes {
+	  t.Error("Implicit Permission ", util.ArrayToString(permission) , name, " under ", domain, ": ", myRes, ", supposed to be ", res)
+	}
+}
+
 func TestGetImplicitRolesForDomainUser(t *testing.T) {
 	e, _ := NewEnforcer("examples/rbac_with_domains_model.conf", "examples/rbac_with_hierarchy_with_domains_policy.csv")
 
@@ -83,6 +93,10 @@ func TestRoleAPIWithDomains(t *testing.T) {
 	testGetRolesInDomain(t, e, "bob", "domain2", []string{"admin"})
 	testGetRolesInDomain(t, e, "admin", "domain2", []string{})
 	testGetRolesInDomain(t, e, "non_exist", "domain2", []string{})
+
+  testHasImplicitPermissionForUserInDomain(t, e, "alice", "domain1", []string{"domain1", "data1", "read"}, true)
+  testHasImplicitPermissionForUserInDomain(t, e, "alice", "domain1", []string{"domain2", "data2", "read"}, false)
+  testHasImplicitPermissionForUserInDomain(t, e, "alice", "domain2", []string{"domain2", "data2", "read"}, false)
 
 	e.DeleteRoleForUserInDomain("alice", "admin", "domain1")
 	e.AddRoleForUserInDomain("bob", "admin", "domain1")


### PR DESCRIPTION
### HasPermissionAmongUsers
Both **HasImplicitPermissionForUserInDomain** and **HasImplicitPermissionForUser** need to go through a name list to find if a permission belongs to one of them. Therefore, I write a function to do these things.
I add a new role in **basic_without_resources_policy** to test this function better. 
### HasImplicitPermissionForUser
This function is for rbac-wthout-domains model. First, we get every implicit role this user can reach. And use **HasPermissionAmongUsers** to determine whether the permission is its implicit permission or not.
### HasImplicitPermissionForUserInDomain
First, I check if the domain is in the permission to avoid case like using role in domain1 to read things in domain2, because of we have no idea which param in permission is domain. The next process is the same as **HasImplicitPermissionForUser**.