### PR TITLE
fix: return panic error when enforce

### DIFF
--- a/enforcer.go
+++ b/enforcer.go
@@ -319,7 +319,7 @@ func (e *Enforcer) EnableLog(enable bool) {
 }
 
 // EnableAutoNotifyWatcher controls whether to save a policy rule automatically notify the Watcher when it is added or removed.
-func (e *Enforcer) EnableAutoNotifyWatcher(enable bool)  {
+func (e *Enforcer) EnableAutoNotifyWatcher(enable bool) {
 	e.autoNotifyWatcher = enable
 }
 
@@ -344,10 +344,10 @@ func (e *Enforcer) BuildRoleLinks() error {
 }
 
 // enforce use a custom matcher to decides whether a "subject" can access a "object" with the operation "action", input parameters are usually: (matcher, sub, obj, act), use model matcher by default when matcher is "".
-func (e *Enforcer) enforce(matcher string, rvals ...interface{}) (bool, error) {
+func (e *Enforcer) enforce(matcher string, rvals ...interface{}) (isOK bool, err error) {
 	defer func() {
-		if err := recover(); err != nil {
-			fmt.Errorf("panic: %v", err)
+		if r := recover(); r != nil {
+			err = fmt.Errorf("panic: %v", r)
 		}
 	}()
 

--- a/util/builtin_operators.go
+++ b/util/builtin_operators.go
@@ -58,7 +58,7 @@ func KeyMatch(key1 string, key2 string) bool {
 // KeyMatchFunc is the wrapper for KeyMatch.
 func KeyMatchFunc(args ...interface{}) (interface{}, error) {
 	if err := validateVariadicArgs(2, args...); err != nil {
-		return false, errors.New(fmt.Sprintf("%s %s", "keyMatch: ", err))
+		return false, errors.New(fmt.Sprintf("%s %s", "keyMatch:", err))
 	}
 
 	name1 := args[0].(string)
@@ -87,7 +87,7 @@ func KeyMatch2(key1 string, key2 string) bool {
 // KeyMatch2Func is the wrapper for KeyMatch2.
 func KeyMatch2Func(args ...interface{}) (interface{}, error) {
 	if err := validateVariadicArgs(2, args...); err != nil {
-		return false, errors.New(fmt.Sprintf("%s %s", "keyMatch2: ", err))
+		return false, errors.New(fmt.Sprintf("%s %s", "keyMatch2:", err))
 	}
 
 	name1 := args[0].(string)
@@ -116,7 +116,7 @@ func KeyMatch3(key1 string, key2 string) bool {
 // KeyMatch3Func is the wrapper for KeyMatch3.
 func KeyMatch3Func(args ...interface{}) (interface{}, error) {
 	if err := validateVariadicArgs(2, args...); err != nil {
-		return false, errors.New(fmt.Sprintf("%s %s", "keyMatch3: ", err))
+		return false, errors.New(fmt.Sprintf("%s %s", "keyMatch3:", err))
 	}
 
 	name1 := args[0].(string)
@@ -188,7 +188,7 @@ func KeyMatch4(key1 string, key2 string) bool {
 // KeyMatch4Func is the wrapper for KeyMatch4.
 func KeyMatch4Func(args ...interface{}) (interface{}, error) {
 	if err := validateVariadicArgs(2, args...); err != nil {
-		return false, errors.New(fmt.Sprintf("%s %s", "keyMatch4: ", err))
+		return false, errors.New(fmt.Sprintf("%s %s", "keyMatch4:", err))
 	}
 
 	name1 := args[0].(string)
@@ -209,7 +209,7 @@ func RegexMatch(key1 string, key2 string) bool {
 // RegexMatchFunc is the wrapper for RegexMatch.
 func RegexMatchFunc(args ...interface{}) (interface{}, error) {
 	if err := validateVariadicArgs(2, args...); err != nil {
-		return false, errors.New(fmt.Sprintf("%s %s", "regexMatch: ", err))
+		return false, errors.New(fmt.Sprintf("%s %s", "regexMatch:", err))
 	}
 
 	name1 := args[0].(string)
@@ -242,7 +242,7 @@ func IPMatch(ip1 string, ip2 string) bool {
 // IPMatchFunc is the wrapper for IPMatch.
 func IPMatchFunc(args ...interface{}) (interface{}, error) {
 	if err := validateVariadicArgs(2, args...); err != nil {
-		return false, errors.New(fmt.Sprintf("%s %s", "ipMatch: ", err))
+		return false, errors.New(fmt.Sprintf("%s %s", "ipMatch:", err))
 	}
 
 	ip1 := args[0].(string)

--- a/util/builtin_operators.go
+++ b/util/builtin_operators.go
@@ -16,6 +16,7 @@ package util
 
 import (
 	"errors"
+	"fmt"
 	"net"
 	"regexp"
 	"strings"
@@ -23,6 +24,22 @@ import (
 	"github.com/Knetic/govaluate"
 	"github.com/casbin/casbin/v2/rbac"
 )
+
+// validate the variadic parameter size and type as string
+func validateVariadicArgs(expectedLen int, args ...interface{}) error {
+	if len(args) != expectedLen {
+		return errors.New(fmt.Sprintf("Expected %d arguments, but got %d", expectedLen, len(args)))
+	}
+
+	for _, p := range args {
+		_, ok := p.(string)
+		if !ok {
+			return errors.New("Argument must be a string")
+		}
+	}
+
+	return nil
+}
 
 // KeyMatch determines whether key1 matches the pattern of key2 (similar to RESTful path), key2 can contain a *.
 // For example, "/foo/bar" matches "/foo/*"
@@ -40,6 +57,10 @@ func KeyMatch(key1 string, key2 string) bool {
 
 // KeyMatchFunc is the wrapper for KeyMatch.
 func KeyMatchFunc(args ...interface{}) (interface{}, error) {
+	if err := validateVariadicArgs(2, args...); err != nil {
+		return false, errors.New(fmt.Sprintf("%s %s", "keyMatch: ", err))
+	}
+
 	name1 := args[0].(string)
 	name2 := args[1].(string)
 
@@ -65,6 +86,10 @@ func KeyMatch2(key1 string, key2 string) bool {
 
 // KeyMatch2Func is the wrapper for KeyMatch2.
 func KeyMatch2Func(args ...interface{}) (interface{}, error) {
+	if err := validateVariadicArgs(2, args...); err != nil {
+		return false, errors.New(fmt.Sprintf("%s %s", "keyMatch2: ", err))
+	}
+
 	name1 := args[0].(string)
 	name2 := args[1].(string)
 
@@ -90,6 +115,10 @@ func KeyMatch3(key1 string, key2 string) bool {
 
 // KeyMatch3Func is the wrapper for KeyMatch3.
 func KeyMatch3Func(args ...interface{}) (interface{}, error) {
+	if err := validateVariadicArgs(2, args...); err != nil {
+		return false, errors.New(fmt.Sprintf("%s %s", "keyMatch3: ", err))
+	}
+
 	name1 := args[0].(string)
 	name2 := args[1].(string)
 
@@ -158,6 +187,10 @@ func KeyMatch4(key1 string, key2 string) bool {
 
 // KeyMatch4Func is the wrapper for KeyMatch4.
 func KeyMatch4Func(args ...interface{}) (interface{}, error) {
+	if err := validateVariadicArgs(2, args...); err != nil {
+		return false, errors.New(fmt.Sprintf("%s %s", "keyMatch4: ", err))
+	}
+
 	name1 := args[0].(string)
 	name2 := args[1].(string)
 
@@ -175,6 +208,10 @@ func RegexMatch(key1 string, key2 string) bool {
 
 // RegexMatchFunc is the wrapper for RegexMatch.
 func RegexMatchFunc(args ...interface{}) (interface{}, error) {
+	if err := validateVariadicArgs(2, args...); err != nil {
+		return false, errors.New(fmt.Sprintf("%s %s", "regexMatch: ", err))
+	}
+
 	name1 := args[0].(string)
 	name2 := args[1].(string)
 
@@ -204,6 +241,10 @@ func IPMatch(ip1 string, ip2 string) bool {
 
 // IPMatchFunc is the wrapper for IPMatch.
 func IPMatchFunc(args ...interface{}) (interface{}, error) {
+	if err := validateVariadicArgs(2, args...); err != nil {
+		return false, errors.New(fmt.Sprintf("%s %s", "ipMatch: ", err))
+	}
+
 	ip1 := args[0].(string)
 	ip2 := args[1].(string)
 

--- a/util/builtin_operators_test.go
+++ b/util/builtin_operators_test.go
@@ -179,3 +179,163 @@ func TestIPMatch(t *testing.T) {
 	testIPMatch(t, "10.0.0.11", "10.0.0.0/8", true)
 	testIPMatch(t, "11.0.0.123", "10.0.0.0/8", false)
 }
+
+func testRegexMatchFunc(t *testing.T, res bool, err string, args ...interface{}) {
+	t.Helper()
+	myRes, myErr := RegexMatchFunc(args...)
+	myErrStr := ""
+
+	if myErr != nil {
+		myErrStr = myErr.Error()
+	}
+
+	if myRes != res || err != myErrStr {
+		t.Errorf("%v returns %v %v, supposed to be %v %v", args, myRes, myErr, res, err)
+	}
+}
+
+func testKeyMatchFunc(t *testing.T, res bool, err string, args ...interface{}) {
+	t.Helper()
+	myRes, myErr := KeyMatchFunc(args...)
+	myErrStr := ""
+
+	if myErr != nil {
+		myErrStr = myErr.Error()
+	}
+
+	if myRes != res || err != myErrStr {
+		t.Errorf("%v returns %v %v, supposed to be %v %v", args, myRes, myErr, res, err)
+	}
+}
+
+func testKeyMatch2Func(t *testing.T, res bool, err string, args ...interface{}) {
+	t.Helper()
+	myRes, myErr := KeyMatch2Func(args...)
+	myErrStr := ""
+
+	if myErr != nil {
+		myErrStr = myErr.Error()
+	}
+
+	if myRes != res || err != myErrStr {
+		t.Errorf("%v returns %v %v, supposed to be %v %v", args, myRes, myErr, res, err)
+	}
+}
+
+func testKeyMatch3Func(t *testing.T, res bool, err string, args ...interface{}) {
+	t.Helper()
+	myRes, myErr := KeyMatch3Func(args...)
+	myErrStr := ""
+
+	if myErr != nil {
+		myErrStr = myErr.Error()
+	}
+
+	if myRes != res || err != myErrStr {
+		t.Errorf("%v returns %v %v, supposed to be %v %v", args, myRes, myErr, res, err)
+	}
+}
+
+func testKeyMatch4Func(t *testing.T, res bool, err string, args ...interface{}) {
+	t.Helper()
+	myRes, myErr := KeyMatch4Func(args...)
+	myErrStr := ""
+
+	if myErr != nil {
+		myErrStr = myErr.Error()
+	}
+
+	if myRes != res || err != myErrStr {
+		t.Errorf("%v returns %v %v, supposed to be %v %v", args, myRes, myErr, res, err)
+	}
+}
+
+func testIPMatchFunc(t *testing.T, res bool, err string, args ...interface{}) {
+	t.Helper()
+	myRes, myErr := IPMatchFunc(args...)
+	myErrStr := ""
+
+	if myErr != nil {
+		myErrStr = myErr.Error()
+	}
+
+	if myRes != res || err != myErrStr {
+		t.Errorf("%v returns %v %v, supposed to be %v %v", args, myRes, myErr, res, err)
+	}
+}
+
+func TestRegexMatchFunc(t *testing.T) {
+	testRegexMatchFunc(t, false, "regexMatch: Expected 2 arguments, but got 1", "/topic/create")
+	testRegexMatchFunc(t, false, "regexMatch: Expected 2 arguments, but got 3", "/topic/create/123", "/topic/create", "/topic/update")
+	testRegexMatchFunc(t, false, "regexMatch: Argument must be a string", "/topic/create", false)
+	testRegexMatchFunc(t, true, "", "/topic/create/123", "/topic/create")
+}
+
+func TestKeyMatchFunc(t *testing.T) {
+	testKeyMatchFunc(t, false, "keyMatch: Expected 2 arguments, but got 1", "/foo")
+	testKeyMatchFunc(t, false, "keyMatch: Expected 2 arguments, but got 3", "/foo/create/123", "/foo/*", "/foo/update/123")
+	testKeyMatchFunc(t, false, "keyMatch: Argument must be a string", "/foo", true)
+	testKeyMatchFunc(t, false, "", "/foo/bar", "/foo")
+	testKeyMatchFunc(t, true, "", "/foo/bar", "/foo/*")
+	testKeyMatchFunc(t, true, "", "/foo/bar", "/foo*")
+}
+
+func TestKeyMatch2Func(t *testing.T) {
+	testKeyMatch2Func(t, false, "keyMatch2: Expected 2 arguments, but got 1", "/")
+	testKeyMatch2Func(t, false, "keyMatch2: Expected 2 arguments, but got 3", "/foo/create/123", "/*", "/foo/update/123")
+	testKeyMatch2Func(t, false, "keyMatch2: Argument must be a string", "/foo", true)
+
+	testKeyMatch2Func(t, false, "", "/", "/:resource")
+	testKeyMatch2Func(t, true, "", "/resource1", "/:resource")
+
+	testKeyMatch2Func(t, true, "", "/foo", "/foo")
+	testKeyMatch2Func(t, true, "", "/foo", "/foo*")
+	testKeyMatch2Func(t, false, "", "/foo", "/foo/*")
+}
+
+func TestKeyMatch3Func(t *testing.T) {
+	testKeyMatch3Func(t, false, "keyMatch3: Expected 2 arguments, but got 1", "/")
+	testKeyMatch3Func(t, false, "keyMatch3: Expected 2 arguments, but got 3", "/foo/create/123", "/*", "/foo/update/123")
+	testKeyMatch3Func(t, false, "keyMatch3: Argument must be a string", "/foo", true)
+
+	testKeyMatch3Func(t, true, "", "/foo", "/foo")
+	testKeyMatch3Func(t, true, "", "/foo", "/foo*")
+	testKeyMatch3Func(t, false, "", "/foo", "/foo/*")
+	testKeyMatch3Func(t, false, "", "/foo/bar", "/foo")
+	testKeyMatch3Func(t, false, "", "/foo/bar", "/foo*")
+	testKeyMatch3Func(t, true, "", "/foo/bar", "/foo/*")
+	testKeyMatch3Func(t, false, "", "/foobar", "/foo")
+	testKeyMatch3Func(t, false, "", "/foobar", "/foo*")
+	testKeyMatch3Func(t, false, "", "/foobar", "/foo/*")
+
+	testKeyMatch3Func(t, false, "", "/", "/{resource}")
+	testKeyMatch3Func(t, true, "", "/resource1", "/{resource}")
+	testKeyMatch3Func(t, false, "", "/myid", "/{id}/using/{resId}")
+	testKeyMatch3Func(t, true, "", "/myid/using/myresid", "/{id}/using/{resId}")
+
+	testKeyMatch3Func(t, false, "", "/proxy/myid", "/proxy/{id}/*")
+	testKeyMatch3Func(t, true, "", "/proxy/myid/", "/proxy/{id}/*")
+	testKeyMatch3Func(t, true, "", "/proxy/myid/res", "/proxy/{id}/*")
+	testKeyMatch3Func(t, true, "", "/proxy/myid/res/res2", "/proxy/{id}/*")
+	testKeyMatch3Func(t, true, "", "/proxy/myid/res/res2/res3", "/proxy/{id}/*")
+	testKeyMatch3Func(t, false, "", "/proxy/", "/proxy/{id}/*")
+}
+
+func TestKeyMatch4Func(t *testing.T) {
+	testKeyMatch4Func(t, false, "keyMatch4: Expected 2 arguments, but got 1", "/parent/123/child/123")
+	testKeyMatch4Func(t, false, "keyMatch4: Expected 2 arguments, but got 3", "/parent/123/child/123", "/parent/{id}/child/{id}", true)
+	testKeyMatch4Func(t, false, "keyMatch4: Argument must be a string", "/parent/123/child/123", true)
+
+	testKeyMatch4Func(t, true, "", "/parent/123/child/123", "/parent/{id}/child/{id}")
+	testKeyMatch4Func(t, false, "", "/parent/123/child/456", "/parent/{id}/child/{id}")
+
+	testKeyMatch4Func(t, true, "", "/parent/123/child/123", "/parent/{id}/child/{another_id}")
+	testKeyMatch4Func(t, true, "", "/parent/123/child/456", "/parent/{id}/child/{another_id}")
+
+}
+
+func TestIPMatchFunc(t *testing.T) {
+	testIPMatchFunc(t, false, "ipMatch: Expected 2 arguments, but got 1", "192.168.2.123")
+	testIPMatchFunc(t, false, "ipMatch: Argument must be a string", "192.168.2.123", 128)
+	testIPMatchFunc(t, true, "", "192.168.2.123", "192.168.2.0/24")
+}


### PR DESCRIPTION
The panic error needs to return to let the user know what happens.

If i write matchers like something below,I will always get false and nil result,I will never know what should be done to fix it except i debug into it.
``` conf
[matchers]
m = g(r.sub, p.sub, r.dom) && r.dom == p.dom && keyMatch(r.obj, p.obj) && regexMatch(r.act, p.act) \
|| r.sub == "root" \ # for root user
|| (p.sub == "*" && keyMatch4(r.obj, p.obj)) # for anonymous user
```