### PR TITLE
Add WatcherEx for change 

### DIFF
--- a/enforcer.go
+++ b/enforcer.go
@@ -303,7 +303,12 @@ func (e *Enforcer) SavePolicy() error {
 		return err
 	}
 	if e.watcher != nil {
+		watcher, ok := e.watcher.(persist.WatcherEx)
+		if ok {
+			return watcher.UpdateForSavePolicy(e.model)
+		}
 		return e.watcher.Update()
+
 	}
 	return nil
 }
@@ -319,7 +324,7 @@ func (e *Enforcer) EnableLog(enable bool) {
 }
 
 // EnableAutoNotifyWatcher controls whether to save a policy rule automatically notify the Watcher when it is added or removed.
-func (e *Enforcer) EnableAutoNotifyWatcher(enable bool)  {
+func (e *Enforcer) EnableAutoNotifyWatcher(enable bool) {
 	e.autoNotifyWatcher = enable
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/casbin/casbin/v2
 
 require github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible
+
+go 1.13

--- a/internal_api.go
+++ b/internal_api.go
@@ -14,6 +14,8 @@
 
 package casbin
 
+import "github.com/casbin/casbin/v2/persist"
+
 const (
 	notImplemented = "not implemented"
 )
@@ -33,10 +35,18 @@ func (e *Enforcer) addPolicy(sec string, ptype string, rule []string) (bool, err
 		}
 	}
 
-	if e.watcher !=nil && e.autoNotifyWatcher {
-		err := e.watcher.Update()
-		if err != nil {
-			return ruleAdded, err
+	if e.watcher != nil && e.autoNotifyWatcher {
+		watcher, ok := e.watcher.(persist.WatcherEx)
+		if ok {
+			err := watcher.UpdateForAddPolicy(rule...)
+			if err != nil {
+				return ruleAdded, err
+			}
+		} else {
+			err := e.watcher.Update()
+			if err != nil {
+				return ruleAdded, err
+			}
 		}
 	}
 
@@ -58,10 +68,17 @@ func (e *Enforcer) removePolicy(sec string, ptype string, rule []string) (bool, 
 		}
 	}
 
-	if e.watcher !=nil && e.autoNotifyWatcher {
-		err := e.watcher.Update()
-		if err != nil {
-			return ruleRemoved, err
+	if e.watcher != nil && e.autoNotifyWatcher {
+		watcher, ok := e.watcher.(persist.WatcherEx)
+		if ok {
+			if err := watcher.UpdateForRemovePolicy(rule...); err != nil {
+				return ruleRemoved, err
+			}
+		} else {
+			err := e.watcher.Update()
+			if err != nil {
+				return ruleRemoved, err
+			}
 		}
 	}
 
@@ -83,10 +100,16 @@ func (e *Enforcer) removeFilteredPolicy(sec string, ptype string, fieldIndex int
 		}
 	}
 
-	if e.watcher !=nil && e.autoNotifyWatcher {
-		err := e.watcher.Update()
-		if err != nil {
-			return ruleRemoved, err
+	if e.watcher != nil && e.autoNotifyWatcher {
+		watcher, ok := e.watcher.(persist.WatcherEx)
+		if ok {
+			if err := watcher.UpdateForRemoveFilteredPolicy(fieldIndex, fieldValues...); err != nil {
+				return ruleRemoved, err
+			}
+		} else {
+			if err := e.watcher.Update(); err != nil {
+				return ruleRemoved, err
+			}
 		}
 	}
 

--- a/persist/watcher.go
+++ b/persist/watcher.go
@@ -14,6 +14,8 @@
 
 package persist
 
+import "github.com/casbin/casbin/v2/model"
+
 // Watcher is the interface for Casbin watchers.
 type Watcher interface {
 	// SetUpdateCallback sets the callback function that the watcher will call
@@ -26,4 +28,21 @@ type Watcher interface {
 	Update() error
 	// Close stops and releases the watcher, the callback function will not be called any more.
 	Close()
+}
+
+// WatcherEx is the strengthen for Casbin watchers.
+type WatcherEx interface {
+	Watcher
+	// UpdateForAddPolicy calls the update callback of other instances to synchronize their policy.
+	// It is called after Enforcer.AddPolicy()
+	UpdateForAddPolicy(params ...interface{}) error
+	// UPdateForRemovePolicy calls the update callback of other instances to synchronize their policy.
+	// It is called after Enforcer.RemovePolicy()
+	UpdateForRemovePolicy(params ...interface{}) error
+	// UpdateForRemoveFilteredPolicy calls the update callback of other instances to synchronize their policy.
+	// It is called after Enforcer.RemoveFilteredNamedGroupingPolicy()
+	UpdateForRemoveFilteredPolicy(fieldIndex int, fieldValues ...string) error
+	// UpdateForSavePolicy calls the update callback of other instances to synchronize their policy.
+	// It is called after Enforcer.RemoveFilteredNamedGroupingPolicy()
+	UpdateForSavePolicy(model model.Model) error
 }

--- a/watcher_test.go
+++ b/watcher_test.go
@@ -14,7 +14,11 @@
 
 package casbin
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/casbin/casbin/v2/model"
+)
 
 type SampleWatcher struct {
 }
@@ -38,4 +42,35 @@ func TestSetWatcher(t *testing.T) {
 	e.SetWatcher(sampleWatcher)
 
 	e.SavePolicy() //calls watcher.Update()
+}
+
+type SampleWatcherEx struct {
+	SampleWatcher
+}
+
+func (w SampleWatcherEx) UpdateForAddPolicy(params ...interface{}) error {
+	return nil
+}
+func (w SampleWatcherEx) UpdateForRemovePolicy(params ...interface{}) error {
+	return nil
+}
+
+func (w SampleWatcherEx) UpdateForRemoveFilteredPolicy(fieldIndex int, fieldValues ...string) error {
+	return nil
+}
+
+func (w SampleWatcherEx) UpdateForSavePolicy(model model.Model) error {
+	return nil
+}
+
+func TestSetWatcherEx(t *testing.T) {
+	e, _ := NewEnforcer("examples/rbac_model.conf", "examples/rbac_policy.csv")
+
+	sampleWatcherEx := SampleWatcherEx{}
+	e.SetWatcher(sampleWatcherEx)
+
+	e.SavePolicy()                           // calls watcherEx.UpdateForSavePolicy()
+	e.AddPolicy("admin", "data1", "read")    // calls watcherEx.UpdateForAddPolicy()
+	e.RemovePolicy("admin", "data1", "read") // calls watcherEx.UpdateForRemovePolicy()
+	e.RemoveFilteredPolicy(1, "data1")       // calls watcherEx.UpdateForRemoveFilteredPolicy()
 }


### PR DESCRIPTION
I added the `WatcherEx` interface, which is an enhancement of the watcher.

The user can customize the update function for `AddPolicy()` ,`RemovePolicy()` ,`RemoveFilteredPolicy()`, `SavePolicy()`.

For the first three, their parameters are the same as those passed in by the user，
But for the `SavePolicy()`,  user who needs to deal with the model, I think this is a bit complicated for the user. Do you have a better way to replace it? 

Or we can delete this function, But I think this function is still very important. It can force synchronization between all nodes.