### PR TITLE
Add exforceEx() for the hit rule

### DIFF
--- a/effect/default_effector_ex.go
+++ b/effect/default_effector_ex.go
@@ -1,0 +1,48 @@
+// Copyright 2020 The casbin Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package effect
+
+import "errors"
+
+// DefaultEffectorEx is default effectorEx for Casbin.
+type DefaultEffectorEx struct {
+	DefaultEffector
+}
+
+// NewDefaultEffectorEx is the constructor for DefaultEffectorEx.
+func NewDefaultEffectorEx() *DefaultEffectorEx {
+	e := DefaultEffectorEx{}
+	return &e
+}
+
+// IsHit return whether it should be returned by exforceEx()
+func (e *DefaultEffectorEx) IsHit(expr string, eft Effect) (bool, error) {
+	if expr == "some(where (p_eft == allow))" {
+		if eft == Allow {
+			return true, nil
+		}
+	} else if expr == "!some(where (p_eft == deny))" || expr == "some(where (p_eft == allow)) && !some(where (p_eft == deny))" {
+		if eft == Deny {
+			return true, nil
+		}
+	} else if expr == "priority(p_eft) || deny" {
+		if eft != Indeterminate {
+			return true, nil
+		}
+	} else {
+		return false, errors.New("unsupported effect")
+	}
+	return false, nil
+}

--- a/effect/effector_ex.go
+++ b/effect/effector_ex.go
@@ -1,0 +1,21 @@
+// Copyright 2020 The casbin Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package effect
+
+// EffectorEx is the interface for Casbin effectors.
+type EffectorEx interface {
+	Effector
+	IsHit(expr string, effect Effect) (bool, error)
+}

--- a/enforcer_interface.go
+++ b/enforcer_interface.go
@@ -49,6 +49,9 @@ type IEnforcer interface {
 	EnableAutoBuildRoleLinks(autoBuildRoleLinks bool)
 	BuildRoleLinks() error
 	Enforce(rvals ...interface{}) (bool, error)
+	EnforceWithMatcher(matcher string, rvals ...interface{}) (bool, error)
+	EnforceEx(rvals ...interface{}) (bool, [][]string, error)
+	EnforceExWithMatcher(matcher string, rvals ...interface{}) (bool, [][]string, error)
 
 	/* RBAC API */
 	GetRolesForUser(name string) ([]string, error)

--- a/examples/enforce_ex_model.conf
+++ b/examples/enforce_ex_model.conf
@@ -1,0 +1,14 @@
+[request_definition]
+r = sub, obj, act
+
+[policy_definition]
+p = sub, obj, act
+
+[role_definition]
+g = _, _
+
+[policy_effect]
+e = some(where (p.eft == allow))
+
+[matchers]
+m = g(r.sub, p.sub) && r.obj == p.obj && r.act == p.act

--- a/examples/enforce_ex_policy.csv
+++ b/examples/enforce_ex_policy.csv
@@ -1,0 +1,5 @@
+p, alice, data1, read
+p, alice, data2, write
+p, data2_admin, data2, read
+p, data2_admin, data2, write
+g, alice, data2_admin


### PR DESCRIPTION
Add `ExforceEx()` for the hit rule，whether it hits depends on user selected effect. User can modify it by interface `EffectorEx`

`exforceEx()` is basically a copy of `exforce()`,I know there is a lot of duplicate code here, but it's hard to reuse them without modifying `enforce()`