### PR TITLE
Added support for the CONF files having just comma (no spaces) separated values.

### DIFF
--- a/examples/basic_model_without_spaces.conf
+++ b/examples/basic_model_without_spaces.conf
@@ -1,0 +1,11 @@
+[request_definition]
+r = sub,obj,act
+
+[policy_definition]
+p = sub,obj,act
+
+[policy_effect]
+e = some(where (p.eft == allow))
+
+[matchers]
+m = r.sub == p.sub && r.obj == p.obj && r.act == p.act

--- a/model/model.go
+++ b/model/model.go
@@ -57,9 +57,9 @@ func (model Model) AddDef(sec string, key string, value string) bool {
 	ast.Value = value
 
 	if sec == "r" || sec == "p" {
-		ast.Tokens = strings.Split(ast.Value, ", ")
+		ast.Tokens = strings.Split(ast.Value, ",")
 		for i := range ast.Tokens {
-			ast.Tokens[i] = key + "_" + ast.Tokens[i]
+			ast.Tokens[i] = key + "_" + strings.TrimSpace(ast.Tokens[i])
 		}
 	} else {
 		ast.Value = util.RemoveComments(util.EscapeAssertion(ast.Value))

--- a/model_test.go
+++ b/model_test.go
@@ -57,6 +57,19 @@ func TestBasicModel(t *testing.T) {
 	testEnforce(t, e, "bob", "data2", "write", true)
 }
 
+func TestBasicModelWithoutSpaces(t *testing.T) {
+	e, _ := NewEnforcer("examples/basic_model_without_spaces.conf", "examples/basic_policy.csv")
+
+	testEnforce(t, e, "alice", "data1", "read", true)
+	testEnforce(t, e, "alice", "data1", "write", false)
+	testEnforce(t, e, "alice", "data2", "read", false)
+	testEnforce(t, e, "alice", "data2", "write", false)
+	testEnforce(t, e, "bob", "data1", "read", false)
+	testEnforce(t, e, "bob", "data1", "write", false)
+	testEnforce(t, e, "bob", "data2", "read", false)
+	testEnforce(t, e, "bob", "data2", "write", true)
+}
+
 func TestBasicModelNoPolicy(t *testing.T) {
 	e, _ := NewEnforcer("examples/basic_model.conf")
 


### PR DESCRIPTION
As saw in issue #412, the users are facing problems parsing ```CONF``` files. So, why don't we extend our support to just comma(no space) separated values ```,``` , not just ```, ```.

In this way, users will be able to write CONF files in both the above ways.