### PR TITLE
Explain enforcement in log

### DIFF
--- a/effect/default_effector.go
+++ b/effect/default_effector.go
@@ -27,49 +27,54 @@ func NewDefaultEffector() *DefaultEffector {
 }
 
 // MergeEffects merges all matching results collected by the enforcer into a single decision.
-func (e *DefaultEffector) MergeEffects(expr string, effects []Effect, results []float64) (bool, error) {
+func (e *DefaultEffector) MergeEffects(expr string, effects []Effect, results []float64) (bool, int, error) {
 	result := false
+	explainIndex := -1
 	if expr == "some(where (p_eft == allow))" {
 		result = false
-		for _, eft := range effects {
+		for i, eft := range effects {
 			if eft == Allow {
 				result = true
+				explainIndex = i
 				break
 			}
 		}
 	} else if expr == "!some(where (p_eft == deny))" {
 		result = true
-		for _, eft := range effects {
+		for i, eft := range effects {
 			if eft == Deny {
 				result = false
+				explainIndex = i
 				break
 			}
 		}
 	} else if expr == "some(where (p_eft == allow)) && !some(where (p_eft == deny))" {
 		result = false
-		for _, eft := range effects {
+		for i, eft := range effects {
 			if eft == Allow {
 				result = true
 			} else if eft == Deny {
 				result = false
+				explainIndex = i
 				break
 			}
 		}
 	} else if expr == "priority(p_eft) || deny" {
 		result = false
-		for _, eft := range effects {
+		for i, eft := range effects {
 			if eft != Indeterminate {
 				if eft == Allow {
 					result = true
 				} else {
 					result = false
 				}
+				explainIndex = i
 				break
 			}
 		}
 	} else {
-		return false, errors.New("unsupported effect")
+		return false, -1, errors.New("unsupported effect")
 	}
 
-	return result, nil
+	return result, explainIndex, nil
 }

--- a/effect/effector.go
+++ b/effect/effector.go
@@ -27,5 +27,5 @@ const (
 // Effector is the interface for Casbin effectors.
 type Effector interface {
 	// MergeEffects merges all matching results collected by the enforcer into a single decision.
-	MergeEffects(expr string, effects []Effect, results []float64) (bool, error)
+	MergeEffects(expr string, effects []Effect, results []float64) (bool, int, error)
 }

--- a/enforcer.go
+++ b/enforcer.go
@@ -344,7 +344,7 @@ func (e *Enforcer) BuildRoleLinks() error {
 }
 
 // enforce use a custom matcher to decides whether a "subject" can access a "object" with the operation "action", input parameters are usually: (matcher, sub, obj, act), use model matcher by default when matcher is "".
-func (e *Enforcer) enforce(matcher string, rvals ...interface{}) (ok bool, err error) {
+func (e *Enforcer) enforce(matcher string, explains *[]string, rvals ...interface{}) (ok bool, err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			err = fmt.Errorf("panic: %v", r)
@@ -394,6 +394,7 @@ func (e *Enforcer) enforce(matcher string, rvals ...interface{}) (ok bool, err e
 
 	var policyEffects []effect.Effect
 	var matcherResults []float64
+
 	if policyLen := len(e.model["p"]["p"].Policy); policyLen != 0 {
 		policyEffects = make([]effect.Effect, policyLen)
 		matcherResults = make([]float64, policyLen)
@@ -480,9 +481,15 @@ func (e *Enforcer) enforce(matcher string, rvals ...interface{}) (ok bool, err e
 
 	// log.LogPrint("Rule Results: ", policyEffects)
 
-	result, err := e.eft.MergeEffects(e.model["e"]["e"].Value, policyEffects, matcherResults)
+	result, explainIndex, err := e.eft.MergeEffects(e.model["e"]["e"].Value, policyEffects, matcherResults)
 	if err != nil {
 		return false, err
+	}
+
+	if explains != nil {
+		if explainIndex != -1 {
+			*explains = e.model["p"]["p"].Policy[explainIndex]
+		}
 	}
 
 	// Log request.
@@ -496,7 +503,20 @@ func (e *Enforcer) enforce(matcher string, rvals ...interface{}) (ok bool, err e
 				reqStr.WriteString(fmt.Sprintf("%v", rval))
 			}
 		}
-		reqStr.WriteString(fmt.Sprintf(" ---> %t", result))
+		reqStr.WriteString(fmt.Sprintf(" ---> %t\n", result))
+
+		if explains != nil {
+			reqStr.WriteString("Hit Policy: ")
+			for i, pval := range *explains {
+				if i != len(*explains)-1 {
+					reqStr.WriteString(fmt.Sprintf("%v, ", pval))
+				} else {
+					reqStr.WriteString(fmt.Sprintf("%v \n", pval))
+				}
+			}
+
+		}
+
 		log.LogPrint(reqStr.String())
 	}
 
@@ -505,12 +525,26 @@ func (e *Enforcer) enforce(matcher string, rvals ...interface{}) (ok bool, err e
 
 // Enforce decides whether a "subject" can access a "object" with the operation "action", input parameters are usually: (sub, obj, act).
 func (e *Enforcer) Enforce(rvals ...interface{}) (bool, error) {
-	return e.enforce("", rvals...)
+	return e.enforce("", nil, rvals...)
 }
 
 // EnforceWithMatcher use a custom matcher to decides whether a "subject" can access a "object" with the operation "action", input parameters are usually: (matcher, sub, obj, act), use model matcher by default when matcher is "".
 func (e *Enforcer) EnforceWithMatcher(matcher string, rvals ...interface{}) (bool, error) {
-	return e.enforce(matcher, rvals...)
+	return e.enforce(matcher, nil, rvals...)
+}
+
+// EnforceEx explain enforcement by informing matched rules
+func (e *Enforcer) EnforceEx(rvals ...interface{}) (bool, []string, error) {
+	explain := []string{}
+	result, err := e.enforce("", &explain, rvals...)
+	return result, explain, err
+}
+
+// EnforceExWithMatcher use a custom matcher and explain enforcement by informing matched rules
+func (e *Enforcer) EnforceExWithMatcher(matcher string, rvals ...interface{}) (bool, []string, error) {
+	explain := []string{}
+	result, err := e.enforce(matcher, &explain, rvals...)
+	return result, explain, err
 }
 
 // assumes bounds have already been checked

--- a/enforcer_interface.go
+++ b/enforcer_interface.go
@@ -37,7 +37,7 @@ type IEnforcer interface {
 	GetAdapter() persist.Adapter
 	SetAdapter(adapter persist.Adapter)
 	SetWatcher(watcher persist.Watcher) error
-	GetRoleManager() rbac.RoleManager;
+	GetRoleManager() rbac.RoleManager
 	SetRoleManager(rm rbac.RoleManager)
 	SetEffector(eft effect.Effector)
 	ClearPolicy()
@@ -51,9 +51,11 @@ type IEnforcer interface {
 	EnableAutoSave(autoSave bool)
 	EnableAutoBuildRoleLinks(autoBuildRoleLinks bool)
 	BuildRoleLinks() error
-	enforce(matcher string, rvals ...interface{}) (bool, error)
+	enforce(matcher string, explains *[]string, rvals ...interface{}) (bool, error)
 	Enforce(rvals ...interface{}) (bool, error)
 	EnforceWithMatcher(matcher string, rvals ...interface{}) (bool, error)
+	EnforceEx(rvals ...interface{}) (bool, []string, error)
+	EnforceExWithMatcher(matcher string, rvals ...interface{}) (bool, []string, error)
 
 	/* RBAC API */
 	GetRolesForUser(name string) ([]string, error)
@@ -75,11 +77,11 @@ type IEnforcer interface {
 	DeletePermission(permission ...string) (bool, error)
 
 	/* RBAC API with domains*/
-	GetUsersForRoleInDomain(name string, domain string) []string;
-	GetRolesForUserInDomain(name string, domain string) []string;
-	GetPermissionsForUserInDomain(user string, domain string) [][]string;
-	AddRoleForUserInDomain(user string, role string, domain string) (bool, error);
-	DeleteRoleForUserInDomain(user string, role string, domain string) (bool, error);
+	GetUsersForRoleInDomain(name string, domain string) []string
+	GetRolesForUserInDomain(name string, domain string) []string
+	GetPermissionsForUserInDomain(user string, domain string) [][]string
+	AddRoleForUserInDomain(user string, role string, domain string) (bool, error)
+	DeleteRoleForUserInDomain(user string, role string, domain string) (bool, error)
 
 	/* Management API */
 	GetAllSubjects() []string

--- a/management_api_test.go
+++ b/management_api_test.go
@@ -154,11 +154,11 @@ func TestModifyPolicyAPI(t *testing.T) {
 	e.AddPolicy("eve", "data3", "read")
 	e.AddPolicy("eve", "data3", "read")
 
-	rules :=[][] string {
-				[]string {"jack", "data4", "read"},
-				[]string {"katy", "data4", "write"},
-				[]string {"leyo", "data4", "read"},
-				[]string {"ham", "data4", "write"},
+	rules := [][]string{
+		{"jack", "data4", "read"},
+		{"katy", "data4", "write"},
+		{"leyo", "data4", "read"},
+		{"ham", "data4", "write"},
 	}
 
 	e.AddPolicies(rules)
@@ -202,9 +202,9 @@ func TestModifyGroupingPolicyAPI(t *testing.T) {
 	e.AddGroupingPolicy("bob", "data1_admin")
 	e.AddGroupingPolicy("eve", "data3_admin")
 
-	groupingRules := [][]string {
-					{"ham", "data4_admin"},
-					{"jack", "data5_admin"},
+	groupingRules := [][]string{
+		{"ham", "data4_admin"},
+		{"jack", "data5_admin"},
 	}
 
 	e.AddGroupingPolicies(groupingRules)

--- a/util/util.go
+++ b/util/util.go
@@ -23,8 +23,8 @@ import (
 // EscapeAssertion escapes the dots in the assertion, because the expression evaluation doesn't support such variable names.
 func EscapeAssertion(s string) string {
 	//Replace the first dot, because it can't be recognized by the regexp.
-	if (strings.HasPrefix(s, "r") || strings.HasPrefix(s, "p")) {
-		s = strings.Replace(s, ".", "_",1)
+	if strings.HasPrefix(s, "r") || strings.HasPrefix(s, "p") {
+		s = strings.Replace(s, ".", "_", 1)
 	}
 	var regex = regexp.MustCompile(`(\|| |=|\)|\(|&|<|>|,|\+|-|!|\*|\/)(r|p)\.`)
 	s = regex.ReplaceAllStringFunc(s, func(m string) string {


### PR DESCRIPTION
For #355
Explain why an enforcement was or wasn't satisfied.Controlled by `autoExplain` in enforce,Print the policy related to the result to the log.

such as `some(where (p.eft == allow))`, the explanation will be all allowed policy.

whether it hits depends on user selected effect. User can modify it by interface EffectorEx