### PR TITLE
ci: add GitHub actions

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -1,0 +1,45 @@
+name: Default
+
+on:
+  push:
+    branches:
+      - master
+    pull_request:
+      - master
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go: [ 1.11, 1.12, 1.13, 1.14]
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go }}
+
+      - name: Get dependencies
+        run: go get -v -t -d ./...
+
+      - name: Test
+        run: go test -v .
+
+  semantic-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Run semantic-release
+        if: github.repository == 'casbin/casbin' && github.event_name == 'push'
+        run: |
+          export PATH="$(yarn global bin):$PATH"
+          yarn global add semantic-release
+          semantic-release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+
+

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,13 @@
+{
+  "debug": true,
+  "release": {
+    "branches": [
+      "master"
+    ]
+  },
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    "@semantic-release/github"
+  ]
+}


### PR DESCRIPTION
The following is supported via GitHub actions: 
- test casbin is working on golang 1.11, 1.12, 1.13, 1.14
- add automate package to Release(#444)


