### PR TITLE
fix: improve KeyMatch method to avoid endless loop

### DIFF
--- a/util/builtin_operators.go
+++ b/util/builtin_operators.go
@@ -73,14 +73,8 @@ func KeyMatchFunc(args ...interface{}) (interface{}, error) {
 func KeyMatch2(key1 string, key2 string) bool {
 	key2 = strings.Replace(key2, "/*", "/.*", -1)
 
-	re := regexp.MustCompile(`(.*):[^/]+(.*)`)
-	for {
-		if !strings.Contains(key2, "/:") {
-			break
-		}
-
-		key2 = re.ReplaceAllString(key2, "$1[^/]+$2")
-	}
+	re := regexp.MustCompile(`:[^/]+`)
+	key2 = re.ReplaceAllString(key2, "$1[^/]+$2")
 
 	return RegexMatch(key1, "^"+key2+"$")
 }
@@ -102,14 +96,8 @@ func KeyMatch2Func(args ...interface{}) (interface{}, error) {
 func KeyMatch3(key1 string, key2 string) bool {
 	key2 = strings.Replace(key2, "/*", "/.*", -1)
 
-	re := regexp.MustCompile(`(.*)\{[^/]+\}(.*)`)
-	for {
-		if !strings.Contains(key2, "/{") {
-			break
-		}
-
-		key2 = re.ReplaceAllString(key2, "$1[^/]+$2")
-	}
+	re := regexp.MustCompile(`\{[^/]+\}`)
+	key2 = re.ReplaceAllString(key2, "$1[^/]+$2")
 
 	return RegexMatch(key1, "^"+key2+"$")
 }
@@ -144,14 +132,8 @@ func KeyMatch4(key1 string, key2 string) bool {
 		}
 	}
 
-	re := regexp.MustCompile(`(.*)\{[^/]+\}(.*)`)
-	for {
-		if !strings.Contains(key2, "/{") {
-			break
-		}
-
-		key2 = re.ReplaceAllString(key2, "$1([^/]+)$2")
-	}
+	re := regexp.MustCompile(`\{[^/]+\}`)
+	key2 = re.ReplaceAllString(key2, "$1([^/]+)$2")
 
 	re = regexp.MustCompile("^" + key2 + "$")
 	values := re.FindStringSubmatch(key1)

--- a/util/builtin_operators_test.go
+++ b/util/builtin_operators_test.go
@@ -90,6 +90,8 @@ func TestKeyMatch2(t *testing.T) {
 	testKeyMatch2(t, "/alice/all", "/:id/all", true)
 	testKeyMatch2(t, "/alice", "/:id/all", false)
 	testKeyMatch2(t, "/alice/all", "/:id", false)
+
+	testKeyMatch2(t, "/alice/all", "/:/all", false)
 }
 
 func testKeyMatch3(t *testing.T, key1 string, key2 string, res bool) {
@@ -125,6 +127,8 @@ func TestKeyMatch3(t *testing.T) {
 	testKeyMatch3(t, "/proxy/myid/res/res2", "/proxy/{id}/*", true)
 	testKeyMatch3(t, "/proxy/myid/res/res2/res3", "/proxy/{id}/*", true)
 	testKeyMatch3(t, "/proxy/", "/proxy/{id}/*", false)
+
+	testKeyMatch3(t, "/myid/using/myresid", "/{id/using/{resId}", false)
 }
 
 func testKeyMatch4(t *testing.T, key1 string, key2 string, res bool) {
@@ -149,6 +153,8 @@ func TestKeyMatch4(t *testing.T) {
 	testKeyMatch4(t, "/parent/123/child/456/book/123", "/parent/{id}/child/{id}/book/{id}", false)
 	testKeyMatch4(t, "/parent/123/child/456/book/", "/parent/{id}/child/{id}/book/{id}", false)
 	testKeyMatch4(t, "/parent/123/child/456", "/parent/{id}/child/{id}/book/{id}", false)
+
+	testKeyMatch4(t, "/parent/123/child/123", "/parent/{i/d}/child/{i/d}", false)
 }
 
 func testRegexMatch(t *testing.T, key1 string, key2 string, res bool) {


### PR DESCRIPTION
fix: #447, improve KeyMatch method to avoid endless loop.