### PR TITLE
fix(synced enforcer): use casbin logger

### DIFF
--- a/enforcer_synced.go
+++ b/enforcer_synced.go
@@ -15,12 +15,12 @@
 package casbin
 
 import (
-	"log"
 	"sync"
 	"time"
 
 	"github.com/Knetic/govaluate"
 	"github.com/casbin/casbin/v2/persist"
+	"github.com/casbin/casbin/v2/log"
 )
 
 // SyncedEnforcer wraps Enforcer and provides synchronized access

--- a/enforcer_synced.go
+++ b/enforcer_synced.go
@@ -19,8 +19,8 @@ import (
 	"time"
 
 	"github.com/Knetic/govaluate"
-	"github.com/casbin/casbin/v2/persist"
 	"github.com/casbin/casbin/v2/log"
+	"github.com/casbin/casbin/v2/persist"
 )
 
 // SyncedEnforcer wraps Enforcer and provides synchronized access
@@ -58,7 +58,7 @@ func (e *SyncedEnforcer) StartAutoLoadPolicy(d time.Duration) {
 			e.autoLoadRunning = false
 		}()
 		n := 1
-		log.Print("Start automatically load policy")
+		log.LogPrintf("Start automatically load policy")
 		for {
 			select {
 			case <-ticker.C:
@@ -68,7 +68,7 @@ func (e *SyncedEnforcer) StartAutoLoadPolicy(d time.Duration) {
 				// log.Print("Load policy for time: ", n)
 				n++
 			case <-e.stopAutoLoad:
-				log.Print("Stop automatically load policy")
+				log.LogPrintf("Stop automatically load policy")
 				return
 			}
 		}


### PR DESCRIPTION
Use "github.com/casbin/casbin/v2/log" instead of "log" package.
It will increase usability -- I need to use the zap logger, but synced logger prints to default logger at the same time as the std log, which can cause a race condition.