### PR TITLE
fix: Disable logger in benchmark

### DIFF
--- a/enforcer_cached_b_test.go
+++ b/enforcer_cached_b_test.go
@@ -26,7 +26,7 @@ func BenchmarkCachedRaw(b *testing.B) {
 }
 
 func BenchmarkCachedBasicModel(b *testing.B) {
-	e, _ := NewCachedEnforcer("examples/basic_model.conf", "examples/basic_policy.csv")
+	e, _ := NewCachedEnforcer("examples/basic_model.conf", "examples/basic_policy.csv", false)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -35,7 +35,7 @@ func BenchmarkCachedBasicModel(b *testing.B) {
 }
 
 func BenchmarkCachedRBACModel(b *testing.B) {
-	e, _ := NewCachedEnforcer("examples/rbac_model.conf", "examples/rbac_policy.csv")
+	e, _ := NewCachedEnforcer("examples/rbac_model.conf", "examples/rbac_policy.csv", false)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -44,7 +44,7 @@ func BenchmarkCachedRBACModel(b *testing.B) {
 }
 
 func BenchmarkCachedRBACModelSmall(b *testing.B) {
-	e, _ := NewCachedEnforcer("examples/rbac_model.conf")
+	e, _ := NewCachedEnforcer("examples/rbac_model.conf", false)
 	// Do not rebuild the role inheritance relations for every AddGroupingPolicy() call.
 	e.EnableAutoBuildRoleLinks(false)
 	// 100 roles, 10 resources.
@@ -64,7 +64,7 @@ func BenchmarkCachedRBACModelSmall(b *testing.B) {
 }
 
 func BenchmarkCachedRBACModelMedium(b *testing.B) {
-	e, _ := NewCachedEnforcer("examples/rbac_model.conf")
+	e, _ := NewCachedEnforcer("examples/rbac_model.conf", false)
 	// Do not rebuild the role inheritance relations for every AddGroupingPolicy() call.
 	e.EnableAutoBuildRoleLinks(false)
 	// 1000 roles, 100 resources.
@@ -90,7 +90,7 @@ func BenchmarkCachedRBACModelMedium(b *testing.B) {
 }
 
 func BenchmarkCachedRBACModelLarge(b *testing.B) {
-	e, _ := NewCachedEnforcer("examples/rbac_model.conf")
+	e, _ := NewCachedEnforcer("examples/rbac_model.conf", false)
 	// Do not rebuild the role inheritance relations for every AddGroupingPolicy() call.
 	e.EnableAutoBuildRoleLinks(false)
 
@@ -117,7 +117,7 @@ func BenchmarkCachedRBACModelLarge(b *testing.B) {
 }
 
 func BenchmarkCachedRBACModelWithResourceRoles(b *testing.B) {
-	e, _ := NewCachedEnforcer("examples/rbac_with_resource_roles_model.conf", "examples/rbac_with_resource_roles_policy.csv")
+	e, _ := NewCachedEnforcer("examples/rbac_with_resource_roles_model.conf", "examples/rbac_with_resource_roles_policy.csv", false)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -126,7 +126,7 @@ func BenchmarkCachedRBACModelWithResourceRoles(b *testing.B) {
 }
 
 func BenchmarkCachedRBACModelWithDomains(b *testing.B) {
-	e, _ := NewCachedEnforcer("examples/rbac_with_domains_model.conf", "examples/rbac_with_domains_policy.csv")
+	e, _ := NewCachedEnforcer("examples/rbac_with_domains_model.conf", "examples/rbac_with_domains_policy.csv", false)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -135,7 +135,7 @@ func BenchmarkCachedRBACModelWithDomains(b *testing.B) {
 }
 
 func BenchmarkCachedABACModel(b *testing.B) {
-	e, _ := NewCachedEnforcer("examples/abac_model.conf")
+	e, _ := NewCachedEnforcer("examples/abac_model.conf", false)
 	data1 := newTestResource("data1", "alice")
 
 	b.ResetTimer()
@@ -145,7 +145,7 @@ func BenchmarkCachedABACModel(b *testing.B) {
 }
 
 func BenchmarkCachedKeyMatchModel(b *testing.B) {
-	e, _ := NewCachedEnforcer("examples/keymatch_model.conf", "examples/keymatch_policy.csv")
+	e, _ := NewCachedEnforcer("examples/keymatch_model.conf", "examples/keymatch_policy.csv", false)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -154,7 +154,7 @@ func BenchmarkCachedKeyMatchModel(b *testing.B) {
 }
 
 func BenchmarkCachedRBACModelWithDeny(b *testing.B) {
-	e, _ := NewCachedEnforcer("examples/rbac_with_deny_model.conf", "examples/rbac_with_deny_policy.csv")
+	e, _ := NewCachedEnforcer("examples/rbac_with_deny_model.conf", "examples/rbac_with_deny_policy.csv", false)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -163,7 +163,7 @@ func BenchmarkCachedRBACModelWithDeny(b *testing.B) {
 }
 
 func BenchmarkCachedPriorityModel(b *testing.B) {
-	e, _ := NewCachedEnforcer("examples/priority_model.conf", "examples/priority_policy.csv")
+	e, _ := NewCachedEnforcer("examples/priority_model.conf", "examples/priority_policy.csv", false)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -172,7 +172,7 @@ func BenchmarkCachedPriorityModel(b *testing.B) {
 }
 
 func BenchmarkCachedRBACModelMediumParallel(b *testing.B) {
-	e, _ := NewCachedEnforcer("examples/rbac_model.conf")
+	e, _ := NewCachedEnforcer("examples/rbac_model.conf", false)
 	// Do not rebuild the role inheritance relations for every AddGroupingPolicy() call.
 	e.EnableAutoBuildRoleLinks(false)
 

--- a/model_b_test.go
+++ b/model_b_test.go
@@ -36,7 +36,7 @@ func BenchmarkRaw(b *testing.B) {
 }
 
 func BenchmarkBasicModel(b *testing.B) {
-	e, _ := NewEnforcer("examples/basic_model.conf", "examples/basic_policy.csv")
+	e, _ := NewEnforcer("examples/basic_model.conf", "examples/basic_policy.csv", false)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -45,7 +45,7 @@ func BenchmarkBasicModel(b *testing.B) {
 }
 
 func BenchmarkRBACModel(b *testing.B) {
-	e, _ := NewEnforcer("examples/rbac_model.conf", "examples/rbac_policy.csv")
+	e, _ := NewEnforcer("examples/rbac_model.conf", "examples/rbac_policy.csv", false)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -54,7 +54,7 @@ func BenchmarkRBACModel(b *testing.B) {
 }
 
 func BenchmarkRBACModelSmall(b *testing.B) {
-	e, _ := NewEnforcer("examples/rbac_model.conf")
+	e, _ := NewEnforcer("examples/rbac_model.conf", false)
 	// Do not rebuild the role inheritance relations for every AddGroupingPolicy() call.
 	e.EnableAutoBuildRoleLinks(false)
 	// 100 roles, 10 resources.
@@ -74,7 +74,7 @@ func BenchmarkRBACModelSmall(b *testing.B) {
 }
 
 func BenchmarkRBACModelMedium(b *testing.B) {
-	e, _ := NewEnforcer("examples/rbac_model.conf")
+	e, _ := NewEnforcer("examples/rbac_model.conf", false)
 	// Do not rebuild the role inheritance relations for every AddGroupingPolicy() call.
 	e.EnableAutoBuildRoleLinks(false)
 
@@ -100,7 +100,7 @@ func BenchmarkRBACModelMedium(b *testing.B) {
 }
 
 func BenchmarkRBACModelLarge(b *testing.B) {
-	e, _ := NewEnforcer("examples/rbac_model.conf")
+	e, _ := NewEnforcer("examples/rbac_model.conf", false)
 	// Do not rebuild the role inheritance relations for every AddGroupingPolicy() call.
 	e.EnableAutoBuildRoleLinks(false)
 
@@ -127,7 +127,7 @@ func BenchmarkRBACModelLarge(b *testing.B) {
 }
 
 func BenchmarkRBACModelWithResourceRoles(b *testing.B) {
-	e, _ := NewEnforcer("examples/rbac_with_resource_roles_model.conf", "examples/rbac_with_resource_roles_policy.csv")
+	e, _ := NewEnforcer("examples/rbac_with_resource_roles_model.conf", "examples/rbac_with_resource_roles_policy.csv", false)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -136,7 +136,7 @@ func BenchmarkRBACModelWithResourceRoles(b *testing.B) {
 }
 
 func BenchmarkRBACModelWithDomains(b *testing.B) {
-	e, _ := NewEnforcer("examples/rbac_with_domains_model.conf", "examples/rbac_with_domains_policy.csv")
+	e, _ := NewEnforcer("examples/rbac_with_domains_model.conf", "examples/rbac_with_domains_policy.csv", false)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -145,7 +145,7 @@ func BenchmarkRBACModelWithDomains(b *testing.B) {
 }
 
 func BenchmarkABACModel(b *testing.B) {
-	e, _ := NewEnforcer("examples/abac_model.conf")
+	e, _ := NewEnforcer("examples/abac_model.conf", false)
 	data1 := newTestResource("data1", "alice")
 
 	b.ResetTimer()
@@ -155,7 +155,7 @@ func BenchmarkABACModel(b *testing.B) {
 }
 
 func BenchmarkKeyMatchModel(b *testing.B) {
-	e, _ := NewEnforcer("examples/keymatch_model.conf", "examples/keymatch_policy.csv")
+	e, _ := NewEnforcer("examples/keymatch_model.conf", "examples/keymatch_policy.csv", false)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {


### PR DESCRIPTION
fix: #465

![Screen Shot 2020-05-22 at 11 02 31 AM](https://user-images.githubusercontent.com/45029442/82626981-c3b9b880-9c1b-11ea-897e-be469399826b.png)

And the rest of the logs are generated by unit tests