### PR TITLE
feat: Support pattern function in 3rd args of g

### DIFF
--- a/errors/rbac_errors.go
+++ b/errors/rbac_errors.go
@@ -18,7 +18,8 @@ import "errors"
 
 // Global errors for rbac defined here
 var (
-	ERR_NAME_NOT_FOUND    = errors.New("error: name does not exist")
-	ERR_DOMAIN_PARAMETER  = errors.New("error: domain should be 1 parameter")
-	ERR_NAMES12_NOT_FOUND = errors.New("error: name1 or name2 does not exist")
+	ERR_NAME_NOT_FOUND       = errors.New("error: name does not exist")
+	ERR_DOMAIN_PARAMETER     = errors.New("error: domain should be 1 parameter")
+	ERR_NAMES12_NOT_FOUND    = errors.New("error: name1 or name2 does not exist")
+	ERR_USE_DOMAIN_PARAMETER = errors.New("error: useDomain should be 1 parameter")
 )

--- a/examples/rbac_with_all_pattern_model.conf
+++ b/examples/rbac_with_all_pattern_model.conf
@@ -1,0 +1,14 @@
+[request_definition]
+r = sub, dom, obj, act
+
+[policy_definition]
+p = sub, dom, obj, act
+
+[role_definition]
+g = _, _, _
+
+[policy_effect]
+e = some(where (p.eft == allow))
+
+[matchers]
+m = r.sub == p.sub && g(r.obj, p.obj, r.dom) && r.dom == p.dom && r.act == p.act 

--- a/examples/rbac_with_all_pattern_policy.csv
+++ b/examples/rbac_with_all_pattern_policy.csv
@@ -1,0 +1,4 @@
+p, alice, domain1, book_group, read
+p, alice, domain2, book_group, write
+
+g, /book/:id, book_group, *

--- a/examples/rbac_with_domain_pattern_model.conf
+++ b/examples/rbac_with_domain_pattern_model.conf
@@ -1,0 +1,14 @@
+[request_definition]
+r = sub, dom, obj, act
+
+[policy_definition]
+p = sub, dom, obj, act
+
+[role_definition]
+g = _, _, _
+
+[policy_effect]
+e = some(where (p.eft == allow))
+
+[matchers]
+m = g(r.sub, p.sub, r.dom) && r.dom == p.dom && r.obj == p.obj && r.act == p.act 

--- a/examples/rbac_with_domain_pattern_policy.csv
+++ b/examples/rbac_with_domain_pattern_policy.csv
@@ -1,0 +1,7 @@
+p, admin, domain1, data1, read
+p, admin, domain1, data1, write
+p, admin, domain2, data2, read
+p, admin, domain2, data2, write
+
+g, alice, admin, *
+g, bob, admin, domain2

--- a/model_test.go
+++ b/model_test.go
@@ -575,7 +575,7 @@ func TestCommentModel(t *testing.T) {
 
 func TestDomainMatchModel(t *testing.T) {
 	e, _ := NewEnforcer("examples/rbac_with_domain_pattern_model.conf", "examples/rbac_with_domain_pattern_policy.csv")
-	e.rm.(*defaultrolemanager.RoleManager).AddMatchingFunc("keyMatch2", util.KeyMatch2, true)
+	e.rm.(*defaultrolemanager.RoleManager).AddDomainMatchingFunc("keyMatch2", util.KeyMatch2)
 
 	testDomainEnforce(t, e, "alice", "domain1", "data1", "read", true)
 	testDomainEnforce(t, e, "alice", "domain1", "data1", "write", true)
@@ -592,7 +592,7 @@ func TestDomainMatchModel(t *testing.T) {
 func TestAllMatchModel(t *testing.T) {
 	e, _ := NewEnforcer("examples/rbac_with_all_pattern_model.conf", "examples/rbac_with_all_pattern_policy.csv")
 	e.rm.(*defaultrolemanager.RoleManager).AddMatchingFunc("keyMatch2", util.KeyMatch2)
-	e.rm.(*defaultrolemanager.RoleManager).AddMatchingFunc("keyMatch2", util.KeyMatch2, true)
+	e.rm.(*defaultrolemanager.RoleManager).AddDomainMatchingFunc("keyMatch2", util.KeyMatch2)
 
 	testDomainEnforce(t, e, "alice", "domain1", "/book/1", "read", true)
 	testDomainEnforce(t, e, "alice", "domain1", "/book/1", "write", false)

--- a/model_test.go
+++ b/model_test.go
@@ -563,7 +563,6 @@ func TestABACPolicy(t *testing.T) {
 
 func TestCommentModel(t *testing.T) {
 	e, _ := NewEnforcer("examples/comment_model.conf", "examples/basic_policy.csv")
-
 	testEnforce(t, e, "alice", "data1", "read", true)
 	testEnforce(t, e, "alice", "data1", "write", false)
 	testEnforce(t, e, "alice", "data2", "read", false)
@@ -572,4 +571,31 @@ func TestCommentModel(t *testing.T) {
 	testEnforce(t, e, "bob", "data1", "write", false)
 	testEnforce(t, e, "bob", "data2", "read", false)
 	testEnforce(t, e, "bob", "data2", "write", true)
+}
+
+func TestDomainMatchModel(t *testing.T) {
+	e, _ := NewEnforcer("examples/rbac_with_domain_pattern_model.conf", "examples/rbac_with_domain_pattern_policy.csv")
+	e.rm.(*defaultrolemanager.RoleManager).AddMatchingFunc("keyMatch2", util.KeyMatch2, true)
+
+	testDomainEnforce(t, e, "alice", "domain1", "data1", "read", true)
+	testDomainEnforce(t, e, "alice", "domain1", "data1", "write", true)
+	testDomainEnforce(t, e, "alice", "domain1", "data2", "read", false)
+	testDomainEnforce(t, e, "alice", "domain1", "data2", "write", false)
+	testDomainEnforce(t, e, "alice", "domain2", "data2", "read", true)
+	testDomainEnforce(t, e, "alice", "domain2", "data2", "write", true)
+	testDomainEnforce(t, e, "bob", "domain2", "data1", "read", false)
+	testDomainEnforce(t, e, "bob", "domain2", "data1", "write", false)
+	testDomainEnforce(t, e, "bob", "domain2", "data2", "read", true)
+	testDomainEnforce(t, e, "bob", "domain2", "data2", "write", true)
+}
+
+func TestAllMatchModel(t *testing.T) {
+	e, _ := NewEnforcer("examples/rbac_with_all_pattern_model.conf", "examples/rbac_with_all_pattern_policy.csv")
+	e.rm.(*defaultrolemanager.RoleManager).AddMatchingFunc("keyMatch2", util.KeyMatch2)
+	e.rm.(*defaultrolemanager.RoleManager).AddMatchingFunc("keyMatch2", util.KeyMatch2, true)
+
+	testDomainEnforce(t, e, "alice", "domain1", "/book/1", "read", true)
+	testDomainEnforce(t, e, "alice", "domain1", "/book/1", "write", false)
+	testDomainEnforce(t, e, "alice", "domain2", "/book/1", "read", false)
+	testDomainEnforce(t, e, "alice", "domain2", "/book/1", "write", true)
 }

--- a/rbac/default-role-manager/role_manager_test.go
+++ b/rbac/default-role-manager/role_manager_test.go
@@ -233,7 +233,7 @@ func TestClear(t *testing.T) {
 
 func TestDomainPartternRole(t *testing.T) {
 	rm := NewRoleManager(10)
-	rm.(*RoleManager).AddMatchingFunc("keyMatch2", util.KeyMatch2, true)
+	rm.(*RoleManager).AddDomainMatchingFunc("keyMatch2", util.KeyMatch2)
 
 	rm.AddLink("u1", "g1", "domain1")
 	rm.AddLink("u2", "g1", "domain2")
@@ -264,7 +264,7 @@ func TestDomainPartternRole(t *testing.T) {
 func TestAllMatchingFunc(t *testing.T) {
 	rm := NewRoleManager(10)
 	rm.(*RoleManager).AddMatchingFunc("keyMatch2", util.KeyMatch2)
-	rm.(*RoleManager).AddMatchingFunc("keyMatch2", util.KeyMatch2, true)
+	rm.(*RoleManager).AddDomainMatchingFunc("keyMatch2", util.KeyMatch2)
 
 	rm.AddLink("/book/:id", "book_group", "*")
 	// Current role inheritance tree after deleting the links:

--- a/rbac_api_test.go
+++ b/rbac_api_test.go
@@ -15,9 +15,10 @@
 package casbin
 
 import (
-	defaultrolemanager "github.com/casbin/casbin/v2/rbac/default-role-manager"
 	"sort"
 	"testing"
+
+	defaultrolemanager "github.com/casbin/casbin/v2/rbac/default-role-manager"
 
 	"github.com/casbin/casbin/v2/errors"
 	"github.com/casbin/casbin/v2/util"
@@ -233,10 +234,6 @@ func TestImplicitRoleAPI(t *testing.T) {
 	e, _ = NewEnforcer("examples/rbac_with_pattern_model.conf", "examples/rbac_with_pattern_policy.csv")
 
 	e.GetRoleManager().(*defaultrolemanager.RoleManager).AddMatchingFunc("matcher", util.KeyMatch)
-	err := e.BuildRoleLinks()
-	if err != nil {
-		t.Error(err)
-	}
 
 	testGetImplicitRoles(t, e, "cathy", []string{"/book/1/2/3/4/5", "pen_admin", "/book/*", "book_group"})
 	testGetRoles(t, e, []string{"/book/1/2/3/4/5", "pen_admin"}, "cathy")


### PR DESCRIPTION
This commit not only supports pattern function in 3rd args of g, but also can be used in policy, such as

```
p, data1_admin, *, data1, read
p, data1_admin, *, data1, write

g, alice, data1_admin, domain1
```