### PR TITLE
perf: Use read lock in synced enforcer

### DIFF
--- a/enforcer_synced.go
+++ b/enforcer_synced.go
@@ -125,8 +125,8 @@ func (e *SyncedEnforcer) BuildRoleLinks() error {
 
 // Enforce decides whether a "subject" can access a "object" with the operation "action", input parameters are usually: (sub, obj, act).
 func (e *SyncedEnforcer) Enforce(rvals ...interface{}) (bool, error) {
-	e.m.Lock()
-	defer e.m.Unlock()
+	e.m.RLock()
+	defer e.m.RUnlock()
 	return e.Enforcer.Enforce(rvals...)
 }
 


### PR DESCRIPTION
Use read lock in `Enforce()` method instead of write lock in synced enforcer.  

Write lock blocks other readers and writers, while read lock do not block other readers. So calling `SyncedEnforcer.Enforce()` can be a performance bottleneck when using `SyncedEnforcer` as singleton, for example.

Previously the read lock was in this method, and in [this PR](https://github.com/casbin/casbin/pull/310) it was changed to write lock due to error related to concurrent map writes. But the error was caused by bug in nested `Enforcer` instance, not synced enforcer. And this bug has been already fixed [here](https://github.com/casbin/casbin/issues/323).  

So we can use read lock again.  
