### PR TITLE
fix: Necessary code changes in buildIncrementalRoleLinks.

### DIFF
--- a/internal_api.go
+++ b/internal_api.go
@@ -61,13 +61,13 @@ func (e *Enforcer) addPolicy(sec string, ptype string, rule []string) (bool, err
 // addPolicies adds rules to the current policy.
 // removePolicies removes rules from the current policy.
 func (e *Enforcer) addPolicies(sec string, ptype string, rules [][]string) (bool, error) {
-	rulesAdded, effects := e.model.AddPolicies(sec, ptype, rules)
+	rulesAdded := e.model.AddPolicies(sec, ptype, rules)
 	if !rulesAdded {
 		return rulesAdded, nil
 	}
 
 	if sec == "g" {
-		err := e.BuildIncrementalRoleLinks(model.PolicyAdd, ptype, effects)
+		err := e.BuildIncrementalRoleLinks(model.PolicyAdd, ptype, rules)
 		if err != nil {
 			return rulesAdded, err
 		}
@@ -129,13 +129,13 @@ func (e *Enforcer) removePolicy(sec string, ptype string, rule []string) (bool, 
 
 // removePolicies removes rules from the current policy.
 func (e *Enforcer) removePolicies(sec string, ptype string, rules [][]string) (bool, error) {
-	rulesRemoved, effects := e.model.RemovePolicies(sec, ptype, rules)
+	rulesRemoved := e.model.RemovePolicies(sec, ptype, rules)
 	if !rulesRemoved {
 		return rulesRemoved, nil
 	}
 
 	if sec == "g" {
-		err := e.BuildIncrementalRoleLinks(model.PolicyRemove, ptype, effects)
+		err := e.BuildIncrementalRoleLinks(model.PolicyRemove, ptype, rules)
 		if err != nil {
 			return rulesRemoved, err
 		}

--- a/internal_api.go
+++ b/internal_api.go
@@ -59,7 +59,6 @@ func (e *Enforcer) addPolicy(sec string, ptype string, rule []string) (bool, err
 }
 
 // addPolicies adds rules to the current policy.
-// removePolicies removes rules from the current policy.
 func (e *Enforcer) addPolicies(sec string, ptype string, rules [][]string) (bool, error) {
 	rulesAdded := e.model.AddPolicies(sec, ptype, rules)
 	if !rulesAdded {

--- a/model/assertion.go
+++ b/model/assertion.go
@@ -66,10 +66,10 @@ func (ast *Assertion) buildIncrementalRoleLinks(rm rbac.RoleManager, op PolicyOp
 func (ast *Assertion) buildRoleLinks(rm rbac.RoleManager) error {
 	ast.RM = rm
 	count := strings.Count(ast.Value, "_")
+	if count < 2 {
+		return errors.New("the number of \"_\" in role definition should be at least 2")
+	}
 	for _, rule := range ast.Policy {
-		if count < 2 {
-			return errors.New("the number of \"_\" in role definition should be at least 2")
-		}
 		if len(rule) < count {
 			return errors.New("grouping policy elements do not meet role definition")
 		}

--- a/model/policy.go
+++ b/model/policy.go
@@ -117,10 +117,10 @@ func (model Model) AddPolicy(sec string, ptype string, rule []string) bool {
 }
 
 // AddPolicies adds policy rules to the model.
-func (model Model) AddPolicies(sec string, ptype string, rules [][]string) (bool, [][]string) {
+func (model Model) AddPolicies(sec string, ptype string, rules [][]string) bool {
 	for i := 0; i < len(rules); i++ {
 		if model.HasPolicy(sec, ptype, rules[i]) {
-			return false, nil
+			return false
 		}
 	}
 
@@ -128,7 +128,7 @@ func (model Model) AddPolicies(sec string, ptype string, rules [][]string) (bool
 		model[sec][ptype].Policy = append(model[sec][ptype].Policy, rules[i])
 	}
 
-	return true, rules
+	return true
 }
 
 // RemovePolicy removes a policy rule from the model.
@@ -144,7 +144,7 @@ func (model Model) RemovePolicy(sec string, ptype string, rule []string) bool {
 }
 
 // RemovePolicies removes policy rules from the model.
-func (model Model) RemovePolicies(sec string, ptype string, rules [][]string) (bool, [][]string) {
+func (model Model) RemovePolicies(sec string, ptype string, rules [][]string) bool {
 OUTER:
 	for j := 0; j < len(rules); j++ {
 		for _, r := range model[sec][ptype].Policy {
@@ -152,19 +152,17 @@ OUTER:
 				continue OUTER
 			}
 		}
-		return false, nil
+		return false
 	}
 
-	var effects [][]string
 	for j := 0; j < len(rules); j++ {
 		for i, r := range model[sec][ptype].Policy {
 			if util.ArrayEquals(rules[j], r) {
-				effects = append(effects, rules[j])
 				model[sec][ptype].Policy = append(model[sec][ptype].Policy[:i], model[sec][ptype].Policy[i+1:]...)
 			}
 		}
 	}
-	return true, effects
+	return true
 }
 
 // RemoveFilteredPolicy removes policy rules based on field filters from the model.


### PR DESCRIPTION
There is no need to record ```effects``` in ```AddPolicies``` and ```RemovePolicies``` as we know that the operations are atomic, so either all rules are successful or none.