### PR TITLE
fix: Perform adapter persist actions before model changes

### DIFF
--- a/error_test.go
+++ b/error_test.go
@@ -125,7 +125,10 @@ func TestMockAdapterErrors(t *testing.T) {
 
 	e, _ := NewEnforcer("examples/rbac_with_domains_model.conf", adapter)
 
-	_, err := e.AddPolicy("admin", "domain3", "data1", "read")
+	added, err := e.AddPolicy("admin", "domain3", "data1", "read")
+	if added {
+		t.Errorf("added should be false")
+	}
 
 	if err == nil {
 		t.Errorf("Should be an error here.")
@@ -134,10 +137,13 @@ func TestMockAdapterErrors(t *testing.T) {
 		t.Log(err.Error())
 	}
 
-	rules := [][]string {
-			{"admin", "domain4", "data1", "read"},
+	rules := [][]string{
+		{"admin", "domain4", "data1", "read"},
 	}
-	_, err = e.AddPolicies(rules)
+	added, err = e.AddPolicies(rules)
+	if added {
+		t.Errorf("added should be false")
+	}
 
 	if err == nil {
 		t.Errorf("Should be an error here.")
@@ -146,7 +152,10 @@ func TestMockAdapterErrors(t *testing.T) {
 		t.Log(err.Error())
 	}
 
-	_, err2 := e.RemoveFilteredPolicy(1, "domain1", "data1")
+	removed, err2 := e.RemoveFilteredPolicy(1, "domain1", "data1")
+	if removed {
+		t.Errorf("removed should be false")
+	}
 
 	if err2 == nil {
 		t.Errorf("Should be an error here.")
@@ -155,7 +164,10 @@ func TestMockAdapterErrors(t *testing.T) {
 		t.Log(err2.Error())
 	}
 
-	_, err3 := e.RemovePolicy("admin", "domain2", "data2", "read")
+	removed, err3 := e.RemovePolicy("admin", "domain2", "data2", "read")
+	if removed {
+		t.Errorf("removed should be false")
+	}
 
 	if err3 == nil {
 		t.Errorf("Should be an error here.")
@@ -164,11 +176,14 @@ func TestMockAdapterErrors(t *testing.T) {
 		t.Log(err3.Error())
 	}
 
-	rules = [][]string {
+	rules = [][]string{
 		{"admin", "domain4", "data1", "read"},
 	}
 
-	_, err = e.RemovePolicies(rules)
+	removed, err = e.RemovePolicies(rules)
+	if removed {
+		t.Errorf("removed should be false")
+	}
 
 	if err == nil {
 		t.Errorf("Should be an error here.")
@@ -176,7 +191,11 @@ func TestMockAdapterErrors(t *testing.T) {
 		t.Log("Test on error: ")
 		t.Log(err.Error())
 	}
-	_, err4 := e.AddGroupingPolicy("bob", "admin2")
+
+	added, err4 := e.AddGroupingPolicy("bob", "admin2")
+	if added {
+		t.Errorf("added should be false")
+	}
 
 	if err4 == nil {
 		t.Errorf("Should be an error here.")
@@ -185,7 +204,10 @@ func TestMockAdapterErrors(t *testing.T) {
 		t.Log(err4.Error())
 	}
 
-	_, err5 := e.AddNamedGroupingPolicy("g", []string{"eve", "admin2", "domain1"})
+	added, err5 := e.AddNamedGroupingPolicy("g", []string{"eve", "admin2", "domain1"})
+	if added {
+		t.Errorf("added should be false")
+	}
 
 	if err5 == nil {
 		t.Errorf("Should be an error here.")
@@ -194,7 +216,10 @@ func TestMockAdapterErrors(t *testing.T) {
 		t.Log(err5.Error())
 	}
 
-	_, err6 := e.AddNamedPolicy("p", []string{"admin2", "domain2", "data2", "write"})
+	added, err6 := e.AddNamedPolicy("p", []string{"admin2", "domain2", "data2", "write"})
+	if added {
+		t.Errorf("added should be false")
+	}
 
 	if err6 == nil {
 		t.Errorf("Should be an error here.")
@@ -203,7 +228,10 @@ func TestMockAdapterErrors(t *testing.T) {
 		t.Log(err6.Error())
 	}
 
-	_, err7 := e.RemoveGroupingPolicy("bob", "admin2")
+	removed, err7 := e.RemoveGroupingPolicy("bob", "admin2")
+	if removed {
+		t.Errorf("removed should be false")
+	}
 
 	if err7 == nil {
 		t.Errorf("Should be an error here.")
@@ -212,7 +240,10 @@ func TestMockAdapterErrors(t *testing.T) {
 		t.Log(err7.Error())
 	}
 
-	_, err8 := e.RemoveFilteredGroupingPolicy(0, "bob")
+	removed, err8 := e.RemoveFilteredGroupingPolicy(0, "bob")
+	if removed {
+		t.Errorf("removed should be false")
+	}
 
 	if err8 == nil {
 		t.Errorf("Should be an error here.")
@@ -221,7 +252,10 @@ func TestMockAdapterErrors(t *testing.T) {
 		t.Log(err8.Error())
 	}
 
-	_, err9 := e.RemoveNamedGroupingPolicy("g", []string{"alice", "admin", "domain1"})
+	removed, err9 := e.RemoveNamedGroupingPolicy("g", []string{"alice", "admin", "domain1"})
+	if removed {
+		t.Errorf("removed should be false")
+	}
 
 	if err9 == nil {
 		t.Errorf("Should be an error here.")
@@ -230,7 +264,10 @@ func TestMockAdapterErrors(t *testing.T) {
 		t.Log(err9.Error())
 	}
 
-	_, err10 := e.RemoveFilteredNamedGroupingPolicy("g", 0, "eve")
+	removed, err10 := e.RemoveFilteredNamedGroupingPolicy("g", 0, "eve")
+	if removed {
+		t.Errorf("removed should be false")
+	}
 
 	if err10 == nil {
 		t.Errorf("Should be an error here.")

--- a/error_test.go
+++ b/error_test.go
@@ -177,9 +177,8 @@ func TestMockAdapterErrors(t *testing.T) {
 	}
 
 	rules = [][]string{
-		{"admin", "domain4", "data1", "read"},
+		{"admin", "domain1", "data1", "read"},
 	}
-
 	removed, err = e.RemovePolicies(rules)
 	if removed {
 		t.Errorf("removed should be false")

--- a/internal_api.go
+++ b/internal_api.go
@@ -25,6 +25,14 @@ const (
 
 // addPolicy adds a rule to the current policy.
 func (e *Enforcer) addPolicy(sec string, ptype string, rule []string) (bool, error) {
+	if e.adapter != nil && e.autoSave {
+		if err := e.adapter.AddPolicy(sec, ptype, rule); err != nil {
+			if err.Error() != notImplemented {
+				return false, err
+			}
+		}
+	}
+
 	ruleAdded := e.model.AddPolicy(sec, ptype, rule)
 	if !ruleAdded {
 		return ruleAdded, nil
@@ -34,14 +42,6 @@ func (e *Enforcer) addPolicy(sec string, ptype string, rule []string) (bool, err
 		err := e.BuildIncrementalRoleLinks(model.PolicyAdd, ptype, [][]string{rule})
 		if err != nil {
 			return ruleAdded, err
-		}
-	}
-
-	if e.adapter != nil && e.autoSave {
-		if err := e.adapter.AddPolicy(sec, ptype, rule); err != nil {
-			if err.Error() != notImplemented {
-				return ruleAdded, err
-			}
 		}
 	}
 
@@ -60,6 +60,14 @@ func (e *Enforcer) addPolicy(sec string, ptype string, rule []string) (bool, err
 
 // addPolicies adds rules to the current policy.
 func (e *Enforcer) addPolicies(sec string, ptype string, rules [][]string) (bool, error) {
+	if e.adapter != nil && e.autoSave {
+		if err := e.adapter.(persist.BatchAdapter).AddPolicies(sec, ptype, rules); err != nil {
+			if err.Error() != notImplemented {
+				return false, err
+			}
+		}
+	}
+
 	rulesAdded := e.model.AddPolicies(sec, ptype, rules)
 	if !rulesAdded {
 		return rulesAdded, nil
@@ -69,14 +77,6 @@ func (e *Enforcer) addPolicies(sec string, ptype string, rules [][]string) (bool
 		err := e.BuildIncrementalRoleLinks(model.PolicyAdd, ptype, rules)
 		if err != nil {
 			return rulesAdded, err
-		}
-	}
-
-	if e.adapter != nil && e.autoSave {
-		if err := e.adapter.(persist.BatchAdapter).AddPolicies(sec, ptype, rules); err != nil {
-			if err.Error() != notImplemented {
-				return rulesAdded, err
-			}
 		}
 	}
 
@@ -92,6 +92,14 @@ func (e *Enforcer) addPolicies(sec string, ptype string, rules [][]string) (bool
 
 // removePolicy removes a rule from the current policy.
 func (e *Enforcer) removePolicy(sec string, ptype string, rule []string) (bool, error) {
+	if e.adapter != nil && e.autoSave {
+		if err := e.adapter.RemovePolicy(sec, ptype, rule); err != nil {
+			if err.Error() != notImplemented {
+				return false, err
+			}
+		}
+	}
+
 	ruleRemoved := e.model.RemovePolicy(sec, ptype, rule)
 	if !ruleRemoved {
 		return ruleRemoved, nil
@@ -101,14 +109,6 @@ func (e *Enforcer) removePolicy(sec string, ptype string, rule []string) (bool, 
 		err := e.BuildIncrementalRoleLinks(model.PolicyRemove, ptype, [][]string{rule})
 		if err != nil {
 			return ruleRemoved, err
-		}
-	}
-
-	if e.adapter != nil && e.autoSave {
-		if err := e.adapter.RemovePolicy(sec, ptype, rule); err != nil {
-			if err.Error() != notImplemented {
-				return ruleRemoved, err
-			}
 		}
 	}
 
@@ -128,6 +128,14 @@ func (e *Enforcer) removePolicy(sec string, ptype string, rule []string) (bool, 
 
 // removePolicies removes rules from the current policy.
 func (e *Enforcer) removePolicies(sec string, ptype string, rules [][]string) (bool, error) {
+	if e.adapter != nil && e.autoSave {
+		if err := e.adapter.(persist.BatchAdapter).RemovePolicies(sec, ptype, rules); err != nil {
+			if err.Error() != notImplemented {
+				return false, err
+			}
+		}
+	}
+
 	rulesRemoved := e.model.RemovePolicies(sec, ptype, rules)
 	if !rulesRemoved {
 		return rulesRemoved, nil
@@ -137,14 +145,6 @@ func (e *Enforcer) removePolicies(sec string, ptype string, rules [][]string) (b
 		err := e.BuildIncrementalRoleLinks(model.PolicyRemove, ptype, rules)
 		if err != nil {
 			return rulesRemoved, err
-		}
-	}
-
-	if e.adapter != nil && e.autoSave {
-		if err := e.adapter.(persist.BatchAdapter).RemovePolicies(sec, ptype, rules); err != nil {
-			if err.Error() != notImplemented {
-				return rulesRemoved, err
-			}
 		}
 	}
 
@@ -160,6 +160,14 @@ func (e *Enforcer) removePolicies(sec string, ptype string, rules [][]string) (b
 
 // removeFilteredPolicy removes rules based on field filters from the current policy.
 func (e *Enforcer) removeFilteredPolicy(sec string, ptype string, fieldIndex int, fieldValues ...string) (bool, error) {
+	if e.adapter != nil && e.autoSave {
+		if err := e.adapter.RemoveFilteredPolicy(sec, ptype, fieldIndex, fieldValues...); err != nil {
+			if err.Error() != notImplemented {
+				return false, err
+			}
+		}
+	}
+
 	ruleRemoved, effects := e.model.RemoveFilteredPolicy(sec, ptype, fieldIndex, fieldValues...)
 	if !ruleRemoved {
 		return ruleRemoved, nil
@@ -169,14 +177,6 @@ func (e *Enforcer) removeFilteredPolicy(sec string, ptype string, fieldIndex int
 		err := e.BuildIncrementalRoleLinks(model.PolicyRemove, ptype, effects)
 		if err != nil {
 			return ruleRemoved, err
-		}
-	}
-
-	if e.adapter != nil && e.autoSave {
-		if err := e.adapter.RemoveFilteredPolicy(sec, ptype, fieldIndex, fieldValues...); err != nil {
-			if err.Error() != notImplemented {
-				return ruleRemoved, err
-			}
 		}
 	}
 

--- a/internal_api.go
+++ b/internal_api.go
@@ -25,15 +25,21 @@ const (
 
 // addPolicy adds a rule to the current policy.
 func (e *Enforcer) addPolicy(sec string, ptype string, rule []string) (bool, error) {
-	if e.adapter != nil && e.autoSave {
-		if err := e.adapter.AddPolicy(sec, ptype, rule); err != nil {
-			if err.Error() != notImplemented {
-				return false, err
+	persistFn := func() error {
+		if e.adapter != nil && e.autoSave {
+			if err := e.adapter.AddPolicy(sec, ptype, rule); err != nil {
+				if err.Error() != notImplemented {
+					return err
+				}
 			}
 		}
+		return nil
 	}
 
-	ruleAdded := e.model.AddPolicy(sec, ptype, rule)
+	ruleAdded, err := e.model.AddPolicy(persistFn, sec, ptype, rule)
+	if err != nil {
+		return false, err
+	}
 	if !ruleAdded {
 		return ruleAdded, nil
 	}
@@ -60,15 +66,21 @@ func (e *Enforcer) addPolicy(sec string, ptype string, rule []string) (bool, err
 
 // addPolicies adds rules to the current policy.
 func (e *Enforcer) addPolicies(sec string, ptype string, rules [][]string) (bool, error) {
-	if e.adapter != nil && e.autoSave {
-		if err := e.adapter.(persist.BatchAdapter).AddPolicies(sec, ptype, rules); err != nil {
-			if err.Error() != notImplemented {
-				return false, err
+	persistFn := func() error {
+		if e.adapter != nil && e.autoSave {
+			if err := e.adapter.(persist.BatchAdapter).AddPolicies(sec, ptype, rules); err != nil {
+				if err.Error() != notImplemented {
+					return err
+				}
 			}
 		}
+		return nil
 	}
 
-	rulesAdded := e.model.AddPolicies(sec, ptype, rules)
+	rulesAdded, err := e.model.AddPolicies(persistFn, sec, ptype, rules)
+	if err != nil {
+		return false, err
+	}
 	if !rulesAdded {
 		return rulesAdded, nil
 	}
@@ -92,15 +104,21 @@ func (e *Enforcer) addPolicies(sec string, ptype string, rules [][]string) (bool
 
 // removePolicy removes a rule from the current policy.
 func (e *Enforcer) removePolicy(sec string, ptype string, rule []string) (bool, error) {
-	if e.adapter != nil && e.autoSave {
-		if err := e.adapter.RemovePolicy(sec, ptype, rule); err != nil {
-			if err.Error() != notImplemented {
-				return false, err
+	persistFn := func() error {
+		if e.adapter != nil && e.autoSave {
+			if err := e.adapter.RemovePolicy(sec, ptype, rule); err != nil {
+				if err.Error() != notImplemented {
+					return err
+				}
 			}
 		}
+		return nil
 	}
 
-	ruleRemoved := e.model.RemovePolicy(sec, ptype, rule)
+	ruleRemoved, err := e.model.RemovePolicy(persistFn, sec, ptype, rule)
+	if err != nil {
+		return false, err
+	}
 	if !ruleRemoved {
 		return ruleRemoved, nil
 	}
@@ -128,15 +146,21 @@ func (e *Enforcer) removePolicy(sec string, ptype string, rule []string) (bool, 
 
 // removePolicies removes rules from the current policy.
 func (e *Enforcer) removePolicies(sec string, ptype string, rules [][]string) (bool, error) {
-	if e.adapter != nil && e.autoSave {
-		if err := e.adapter.(persist.BatchAdapter).RemovePolicies(sec, ptype, rules); err != nil {
-			if err.Error() != notImplemented {
-				return false, err
+	persistFn := func() error {
+		if e.adapter != nil && e.autoSave {
+			if err := e.adapter.(persist.BatchAdapter).RemovePolicies(sec, ptype, rules); err != nil {
+				if err.Error() != notImplemented {
+					return err
+				}
 			}
 		}
+		return nil
 	}
 
-	rulesRemoved := e.model.RemovePolicies(sec, ptype, rules)
+	rulesRemoved, err := e.model.RemovePolicies(persistFn, sec, ptype, rules)
+	if err != nil {
+		return false, err
+	}
 	if !rulesRemoved {
 		return rulesRemoved, nil
 	}
@@ -160,15 +184,21 @@ func (e *Enforcer) removePolicies(sec string, ptype string, rules [][]string) (b
 
 // removeFilteredPolicy removes rules based on field filters from the current policy.
 func (e *Enforcer) removeFilteredPolicy(sec string, ptype string, fieldIndex int, fieldValues ...string) (bool, error) {
-	if e.adapter != nil && e.autoSave {
-		if err := e.adapter.RemoveFilteredPolicy(sec, ptype, fieldIndex, fieldValues...); err != nil {
-			if err.Error() != notImplemented {
-				return false, err
+	persistFn := func() error {
+		if e.adapter != nil && e.autoSave {
+			if err := e.adapter.RemoveFilteredPolicy(sec, ptype, fieldIndex, fieldValues...); err != nil {
+				if err.Error() != notImplemented {
+					return err
+				}
 			}
 		}
+		return nil
 	}
 
-	ruleRemoved, effects := e.model.RemoveFilteredPolicy(sec, ptype, fieldIndex, fieldValues...)
+	ruleRemoved, effects, err := e.model.RemoveFilteredPolicy(persistFn, sec, ptype, fieldIndex, fieldValues...)
+	if err != nil {
+		return false, err
+	}
 	if !ruleRemoved {
 		return ruleRemoved, nil
 	}


### PR DESCRIPTION
Should resolve #415.

> If the model changes are made first but the adapter fails (network, code error, anything really), the in-memory model and adapter store will be out of sync. The next time the adapter is instantiated it will call LoadPolicy(x) in the store and the changes made in-memory will obviously be lost.

This change moves the adapter action to be first. The mutation of in-memory state is done only if the store does not error (not implemented should be fine still).