### PR TITLE
perf: Parallelize Policy Evaluation

### DIFF
--- a/model_test.go
+++ b/model_test.go
@@ -30,6 +30,13 @@ func testEnforce(t *testing.T, e *Enforcer, sub interface{}, obj interface{}, ac
 	}
 }
 
+func benchmarkEnforce(b *testing.B, e *Enforcer, sub interface{}, obj interface{}, act string, res bool) {
+	b.Helper()
+	if myRes, _ := e.Enforce(sub, obj, act); myRes != res {
+		b.Errorf("%s, %v, %s: %t, supposed to be %t", sub, obj, act, myRes, res)
+	}
+}
+
 func testEnforceWithoutUsers(t *testing.T, e *Enforcer, obj string, act string, res bool) {
 	t.Helper()
 	if myRes, _ := e.Enforce(obj, act); myRes != res {


### PR DESCRIPTION
Fix: https://github.com/casbin/casbin/issues/516

In uses cases that policy evaluation is bottle necked in IO operation (such as database query/API calls), it is much faster to parallelize the evaluation. This trade speed in other cases, due to regeneration of several entity. However, performance cost is small compared to the benefit that we get from parallelizing the entire evaluation, such as big number of policy or IO-heavy operation.