### PR TITLE
fix: remove check request_definition and policy_definition tokens

### DIFF
--- a/enforcer.go
+++ b/enforcer.go
@@ -412,13 +412,6 @@ func (e *Enforcer) enforce(matcher string, explains *[]string, rvals ...interfac
 	if policyLen := len(e.model["p"]["p"].Policy); policyLen != 0 {
 		policyEffects = make([]effect.Effect, policyLen)
 		matcherResults = make([]float64, policyLen)
-		if len(e.model["r"]["r"].Tokens) != len(rvals) {
-			return false, fmt.Errorf(
-				"invalid request size: expected %d, got %d, rvals: %v",
-				len(e.model["r"]["r"].Tokens),
-				len(rvals),
-				rvals)
-		}
 		for i, pvals := range e.model["p"]["p"].Policy {
 			// log.LogPrint("Policy Rule: ", pvals)
 			if len(e.model["p"]["p"].Tokens) != len(pvals) {


### PR DESCRIPTION
Signed-off-by: Zixuan Liu <nodeces@gmail.com>

actually,  we should allow users to add metadata to request_definition or policy_definition, examples:

```
[request_definition]
r = sub, obj, act

# notes is metadata.
[policy_definition]
p = sub, obj, act, notes

[policy_effect]
e = some(where (p.eft == allow))

[matchers]
m = r.sub == p.sub && r.obj == p.obj && r.act == p.act
```