### PR TITLE
fix: update enforcer logic when there is no policy found

### DIFF
--- a/enforcer.go
+++ b/enforcer.go
@@ -493,6 +493,10 @@ func (e *Enforcer) enforce(matcher string, explains *[]string, rvals ...interfac
 
 		}
 	} else {
+		if hasEval && len(e.model["p"]["p"].Policy) == 0 {
+			return false, errors.New("please make sure rule exists in policy when using eval() in matcher")
+		}
+
 		policyEffects = make([]effect.Effect, 1)
 		matcherResults = make([]float64, 1)
 
@@ -520,7 +524,7 @@ func (e *Enforcer) enforce(matcher string, explains *[]string, rvals ...interfac
 	}
 
 	if explains != nil {
-		if explainIndex != -1 {
+		if explainIndex != -1 && len(e.model["p"]["p"].Policy) > explainIndex {
 			*explains = e.model["p"]["p"].Policy[explainIndex]
 		}
 	}

--- a/enforcer_test.go
+++ b/enforcer_test.go
@@ -420,7 +420,7 @@ func TestInitEmpty(t *testing.T) {
 
 	testEnforce(t, e, "alice", "/alice_data/resource1", "GET", true)
 }
-func testEnforceEx(t *testing.T, e *Enforcer, sub string, obj string, act string, res []string) {
+func testEnforceEx(t *testing.T, e *Enforcer, sub, obj, act interface{}, res []string) {
 	t.Helper()
 	_, myRes, _ := e.EnforceEx(sub, obj, act)
 
@@ -461,6 +461,10 @@ func TestEnforceEx(t *testing.T) {
 	testEnforceEx(t, e, "bob", "data1", "write", []string{})
 	testEnforceEx(t, e, "bob", "data2", "read", []string{"data2_allow_group", "data2", "read", "allow"})
 	testEnforceEx(t, e, "bob", "data2", "write", []string{"bob", "data2", "write", "deny"})
+
+	e, _ = NewEnforcer("examples/abac_model.conf")
+	obj := struct{ Owner string }{Owner: "alice"}
+	testEnforceEx(t, e, "alice", obj, "write", []string{})
 }
 
 func TestEnforceExLog(t *testing.T) {

--- a/error_test.go
+++ b/error_test.go
@@ -17,7 +17,7 @@ package casbin
 import (
 	"testing"
 
-	"github.com/casbin/casbin/v2/persist/file-adapter"
+	fileadapter "github.com/casbin/casbin/v2/persist/file-adapter"
 )
 
 func TestPathError(t *testing.T) {
@@ -70,8 +70,16 @@ func TestModelError(t *testing.T) {
 
 func TestEnforceError(t *testing.T) {
 	e, _ := NewEnforcer("examples/basic_model.conf", "examples/basic_policy.csv")
-
 	_, err := e.Enforce("wrong", "wrong")
+	if err == nil {
+		t.Errorf("Should be error here.")
+	} else {
+		t.Log("Test on error: ")
+		t.Log(err.Error())
+	}
+
+	e, _ = NewEnforcer("examples/abac_rule_model.conf")
+	_, err = e.Enforce("wang", "wang", "wang")
 	if err == nil {
 		t.Errorf("Should be error here.")
 	} else {


### PR DESCRIPTION
When there is no policy found:
1. Provide better error message when using eval() in matcher.
2. It is unnecessary to throw a null pointer error when use EnforceEx function, "explainIndex" is return by interface, should check this value, make sure that this value does not break the rest of the logic.