### PR TITLE
fix: Separate internal_api

### DIFF
--- a/enforcer.go
+++ b/enforcer.go
@@ -224,8 +224,8 @@ func (e *Enforcer) SetAdapter(adapter persist.Adapter) {
 	e.internal = internal.NewPolicyManager(e.model, adapter, e.rm)
 }
 
-// GetInternalController gets the current internal controller.
-func (e *Enforcer) GetInternalController() internal.PolicyManager {
+// GetPolicyManager gets the current policy manager.
+func (e *Enforcer) GetPolicyManager() internal.PolicyManager {
 	return e.internal
 }
 

--- a/enforcer_interface.go
+++ b/enforcer_interface.go
@@ -101,15 +101,6 @@ type IEnforcerMgmt interface {
 	AddFunction(name string, function govaluate.ExpressionFunction)
 }
 
-// IEnforcerInternal is the Internal API interface of Enforcer
-type IEnforcerInternal interface {
-	AddPolicyInternal(sec string, ptype string, rule []string) (bool, error)
-	AddPoliciesInternal(sec string, ptype string, rules [][]string) (bool, error)
-	RemovePolicyInternal(sec string, ptype string, rule []string) (bool, error)
-	RemovePoliciesInternal(sec string, ptype string, rules [][]string) (bool, error)
-	RemoveFilteredPolicyInternal(sec string, ptype string, fieldIndex int, fieldValues ...string) (bool, [][]string, error)
-}
-
 // IEnforcer is the API interface of Enforcer
 type IEnforcer interface {
 	/* Management API */
@@ -118,8 +109,6 @@ type IEnforcer interface {
 	/* RBAC API */
 	IEnforcerRbac
 
-	/* Internal API */
-	IEnforcerInternal
 	/* Enforcer API */
 	InitWithFile(modelPath string, policyPath string) error
 	InitWithAdapter(modelPath string, adapter persist.Adapter) error

--- a/enforcer_interface.go
+++ b/enforcer_interface.go
@@ -101,6 +101,15 @@ type IEnforcerMgmt interface {
 	AddFunction(name string, function govaluate.ExpressionFunction)
 }
 
+// IEnforcerInternal is the Internal API interface of Enforcer
+type IEnforcerInternal interface {
+	AddPolicyInternal(sec string, ptype string, rule []string) (bool, error)
+	AddPoliciesInternal(sec string, ptype string, rules [][]string) (bool, error)
+	RemovePolicyInternal(sec string, ptype string, rule []string) (bool, error)
+	RemovePoliciesInternal(sec string, ptype string, rules [][]string) (bool, error)
+	RemoveFilteredPolicyInternal(sec string, ptype string, fieldIndex int, fieldValues ...string) (bool, [][]string, error)
+}
+
 // IEnforcer is the API interface of Enforcer
 type IEnforcer interface {
 	/* Management API */
@@ -109,6 +118,8 @@ type IEnforcer interface {
 	/* RBAC API */
 	IEnforcerRbac
 
+	/* Internal API */
+	IEnforcerInternal
 	/* Enforcer API */
 	InitWithFile(modelPath string, policyPath string) error
 	InitWithAdapter(modelPath string, adapter persist.Adapter) error

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -1,0 +1,171 @@
+package internal
+
+import (
+	"github.com/casbin/casbin/v3/errors"
+	"github.com/casbin/casbin/v3/model"
+	"github.com/casbin/casbin/v3/persist"
+	"github.com/casbin/casbin/v3/rbac"
+)
+
+// PolicyManager is the policy manager for model and adapter
+type PolicyManager interface {
+	AddPolicy(sec string, ptype string, rule []string, shouldPersist bool) (bool, error)
+	AddPolicies(sec string, ptype string, rules [][]string, shouldPersist bool) (bool, error)
+	RemovePolicy(sec string, ptype string, rule []string, shouldPersist bool) (bool, error)
+	RemovePolicies(sec string, ptype string, rules [][]string, shouldPersist bool) (bool, error)
+	RemoveFilteredPolicy(sec string, ptype string, shouldPersist bool, fieldIndex int, fieldValues ...string) (bool, [][]string, error)
+}
+
+type policyManager struct {
+	model   *model.Model
+	adapter persist.Adapter
+	rm      rbac.RoleManager
+}
+
+const (
+	notImplemented = "not implemented"
+)
+
+// NewPolicyManager is the constructor for InternalController
+func NewPolicyManager(model *model.Model, adapter persist.Adapter, rm rbac.RoleManager) PolicyManager {
+	return &policyManager{
+		model:   model,
+		adapter: adapter,
+		rm:      rm,
+	}
+}
+
+// AddPolicy adds a rule to model and adapter.
+func (p *policyManager) AddPolicy(sec string, ptype string, rule []string, shouldPersist bool) (bool, error) {
+	if p.model.HasPolicy(sec, ptype, rule) {
+		return false, nil
+	}
+
+	if shouldPersist {
+		if err := p.adapter.AddPolicy(sec, ptype, rule); err != nil {
+			if err.Error() != notImplemented {
+				return false, err
+			}
+		}
+	}
+
+	p.model.AddPolicy(sec, ptype, rule)
+
+	if sec == "g" {
+		err := p.model.BuildIncrementalRoleLinks(p.rm, model.PolicyAdd, "g", ptype, [][]string{rule})
+		if err != nil {
+			return true, err
+		}
+	}
+
+	return true, nil
+}
+
+// AddPolicies adds rules to model and adapter.
+func (p *policyManager) AddPolicies(sec string, ptype string, rules [][]string, shouldPersist bool) (bool, error) {
+	if p.model.HasPolicies(sec, ptype, rules) {
+		return false, nil
+	}
+
+	if shouldPersist {
+		if err := p.adapter.(persist.BatchAdapter).AddPolicies(sec, ptype, rules); err != nil {
+			if err.Error() != notImplemented {
+				return false, err
+			}
+		}
+	}
+
+	p.model.AddPolicies(sec, ptype, rules)
+
+	if sec == "g" {
+		err := p.model.BuildIncrementalRoleLinks(p.rm, model.PolicyAdd, "g", ptype, rules)
+		if err != nil {
+			return true, err
+		}
+	}
+
+	return true, nil
+}
+
+// RemovePolicy removes a rule from model and adapter.
+func (p *policyManager) RemovePolicy(sec string, ptype string, rule []string, shouldPersist bool) (bool, error) {
+	if shouldPersist {
+		if err := p.adapter.RemovePolicy(sec, ptype, rule); err != nil {
+			if err.Error() != notImplemented {
+				return false, err
+			}
+		}
+	}
+
+	ruleRemoved := p.model.RemovePolicy(sec, ptype, rule)
+	if !ruleRemoved {
+		return ruleRemoved, nil
+	}
+
+	if sec == "g" {
+		err := p.model.BuildIncrementalRoleLinks(p.rm, model.PolicyRemove, "g", ptype, [][]string{rule})
+		if err != nil {
+			return ruleRemoved, err
+		}
+	}
+
+	return ruleRemoved, nil
+}
+
+// RemovePolicies removes rules from model and adapter.
+func (p *policyManager) RemovePolicies(sec string, ptype string, rules [][]string, shouldPersist bool) (bool, error) {
+	if !p.model.HasPolicies(sec, ptype, rules) {
+		return false, nil
+	}
+
+	if shouldPersist {
+		if err := p.adapter.(persist.BatchAdapter).RemovePolicies(sec, ptype, rules); err != nil {
+			if err.Error() != notImplemented {
+				return false, err
+			}
+		}
+	}
+
+	rulesRemoved := p.model.RemovePolicies(sec, ptype, rules)
+	if !rulesRemoved {
+		return rulesRemoved, nil
+	}
+
+	if sec == "g" {
+		err := p.model.BuildIncrementalRoleLinks(p.rm, model.PolicyRemove, "g", ptype, rules)
+		if err != nil {
+			return rulesRemoved, err
+		}
+	}
+
+	return rulesRemoved, nil
+}
+
+// RemoveFilteredPolicy removes rules based on field filters from model and adapter.
+func (p *policyManager) RemoveFilteredPolicy(sec string, ptype string, shouldPersist bool, fieldIndex int, fieldValues ...string) (bool, [][]string, error) {
+	if len(fieldValues) == 0 {
+		return false, nil, errors.INVALID_FIELDVAULES_PARAMETER
+	}
+
+	if shouldPersist {
+		if err := p.adapter.RemoveFilteredPolicy(sec, ptype, fieldIndex, fieldValues...); err != nil {
+			if err.Error() != notImplemented {
+				return false, nil, err
+			}
+		}
+	}
+
+	ruleRemoved, effects := p.model.RemoveFilteredPolicy(sec, ptype, fieldIndex, fieldValues...)
+	if !ruleRemoved {
+		return ruleRemoved, effects, nil
+	}
+
+	if sec == "g" {
+		err := p.model.BuildIncrementalRoleLinks(p.rm, model.PolicyRemove, "g", ptype, effects)
+		if err != nil {
+			return ruleRemoved, effects, err
+		}
+	}
+
+	return ruleRemoved, effects, nil
+}

--- a/internal_api.go
+++ b/internal_api.go
@@ -57,7 +57,7 @@ func (e *Enforcer) addPolicies(sec string, ptype string, rules [][]string) (bool
 		return true, e.dispatcher.AddPolicies(sec, ptype, rules)
 	}
 
-	result, err := e.internal.AddPolicies(sec, ptype, rules, e.shouldPersist())
+	result, effects, err := e.internal.AddPolicies(sec, ptype, rules, e.shouldPersist())
 	if err != nil || !result {
 		return result, err
 	}
@@ -70,7 +70,7 @@ func (e *Enforcer) addPolicies(sec string, ptype string, rules [][]string) (bool
 	}
 
 	if log.GetLogger().IsEnabled() {
-		log.LogPrintf("Policy Management, Type: AddPolicies Assertion: %s::%s\nrules: %s", sec, ptype, util.Array2DToString(rules))
+		log.LogPrintf("Policy Management, Type: AddPolicies Assertion: %s::%s\nrules: %s", sec, ptype, util.Array2DToString(effects))
 	}
 
 	return true, nil
@@ -111,7 +111,7 @@ func (e *Enforcer) removePolicies(sec string, ptype string, rules [][]string) (b
 		return true, e.dispatcher.RemovePolicies(sec, ptype, rules)
 	}
 
-	rulesRemoved, err := e.internal.RemovePolicies(sec, ptype, rules, e.shouldPersist())
+	rulesRemoved, effects, err := e.internal.RemovePolicies(sec, ptype, rules, e.shouldPersist())
 	if err != nil || !rulesRemoved {
 		return rulesRemoved, err
 	}
@@ -124,7 +124,7 @@ func (e *Enforcer) removePolicies(sec string, ptype string, rules [][]string) (b
 	}
 
 	if log.GetLogger().IsEnabled() {
-		log.LogPrintf("Policy Management, Type: RemovePolicies Assertion %s::%s\nrules: %s", sec, ptype, util.Array2DToString(rules))
+		log.LogPrintf("Policy Management, Type: RemovePolicies Assertion %s::%s\nrules: %s", sec, ptype, util.Array2DToString(effects))
 	}
 
 	return rulesRemoved, nil

--- a/model/policy.go
+++ b/model/policy.go
@@ -276,3 +276,31 @@ func (model *Model) GetValuesForFieldInPolicyAllTypes(sec string, fieldIndex int
 
 	return values
 }
+
+// RemoveExistPolicy remove the policy rules already in the model.
+func (model *Model) RemoveExistPolicy(sec string, ptype string, rules [][]string) [][]string {
+	model.mutex.RLock()
+	defer model.mutex.RUnlock()
+	var res [][]string
+	for _, rule := range rules {
+		if _, ok := model.data[sec][ptype].PolicyMap[strings.Join(rule, DefaultSep)]; !ok {
+			res = append(res, rule)
+		}
+	}
+
+	return res
+}
+
+// RemoveNotExistPolicy removes the policy rules not in the model
+func (model *Model) RemoveNotExistPolicy(sec string, ptype string, rules [][]string) [][]string {
+	model.mutex.RLock()
+	defer model.mutex.RUnlock()
+	var res [][]string
+	for _, rule := range rules {
+		if _, ok := model.data[sec][ptype].PolicyMap[strings.Join(rule, DefaultSep)]; ok {
+			res = append(res, rule)
+		}
+	}
+
+	return res
+}


### PR DESCRIPTION
Signed-off-by: dovics <wrs369@163.com>

Now the return value of internal_api is too much, this function need to processe include model, adapter, dispatcher, watcher and logger. I think this function should be simplified.

When the dispatcher updates the policy, it needs to update model and adapter one by one and call `BuildIncrementalRoleLinks()`, which makes the development of the plug-in more complicated, so I separated the main component model and adapter as a new api that can be called from outside.