### PR TITLE
fix: prevent concurrent map writes in LoadPolicyLine function

### DIFF
--- a/persist/adapter.go
+++ b/persist/adapter.go
@@ -17,9 +17,12 @@ package persist
 import (
 	"encoding/csv"
 	"strings"
+	"sync"
 
 	"github.com/casbin/casbin/v2/model"
 )
+
+var loadMutex sync.Mutex
 
 // LoadPolicyLine loads a text line as a policy rule to model.
 func LoadPolicyLine(line string, m model.Model) {
@@ -39,6 +42,10 @@ func LoadPolicyLine(line string, m model.Model) {
 
 	key := tokens[0]
 	sec := key[:1]
+
+	loadMutex.Lock()
+	defer loadMutex.Unlock()
+
 	m[sec][key].Policy = append(m[sec][key].Policy, tokens[1:])
 	m[sec][key].PolicyMap[strings.Join(tokens[1:], model.DefaultSep)] = len(m[sec][key].Policy) - 1
 }


### PR DESCRIPTION
I managed to create an environment in which the `LoadPolicyLine` function regularly causes `concurrent map writes` panics. Added a global `sync.Mutex` object that is used exclusively within the `LoadPolicyLine` function. Have not encountered any locks or concurrent map writes since this addition.

```
fatal error: concurrent map writes

goroutine 2247 [running]:
runtime.throw(0xdd5620, 0x15)
        /usr/local/go/src/runtime/panic.go:1116 +0x72 fp=0xc000175278 sp=0xc000175248 pc=0x43d8d2
runtime.mapassign_faststr(0xcfd340, 0xc0001db200, 0xc0004d7fa0, 0x19, 0xc0002d1818)
        /usr/local/go/src/runtime/map_faststr.go:291 +0x3d8 fp=0xc0001752e0 sp=0xc000175278 pc=0x41be78
github.com/casbin/casbin/v2/persist.LoadPolicyLine(0xc0004d7f20, 0x1e, 0xc0002a9ce0)
        /home/example/go/pkg/mod/github.com/casbin/casbin/v2@v2.13.1/persist/adapter.go:43 +0x547 fp=0xc000175470 sp=0xc0001752e0 pc=0x9fbcc7
```