### PR TITLE
feat: change global logger to enforcer

### DIFF
--- a/enforcer_synced.go
+++ b/enforcer_synced.go
@@ -65,8 +65,7 @@ func (e *SyncedEnforcer) StartAutoLoadPolicy(d time.Duration) {
 			atomic.StoreInt32(&(e.autoLoadRunning), int32(0))
 		}()
 		n := 1
-		//log.LogPrintf("Start automatically load policy")
-		log.LogPolicy(log.LogTypeLoadPolicy, "Start automatically load policy", nil, nil, nil, nil)
+		e.logger.LogPolicy(log.LogTypeLoadPolicy, "Start automatically load policy", nil, nil, nil, nil)
 		for {
 			select {
 			case <-ticker.C:
@@ -76,8 +75,7 @@ func (e *SyncedEnforcer) StartAutoLoadPolicy(d time.Duration) {
 				// log.Print("Load policy for time: ", n)
 				n++
 			case <-e.stopAutoLoad:
-				//log.LogPrintf("Stop automatically load policy")
-				log.LogPolicy(log.LogTypeLoadPolicy, "Stop automatically load policy", nil, nil, nil, nil)
+				e.logger.LogPolicy(log.LogTypeLoadPolicy, "Stop automatically load policy", nil, nil, nil, nil)
 				return
 			}
 		}

--- a/log/default_logger.go
+++ b/log/default_logger.go
@@ -14,39 +14,44 @@
 
 package log
 
-import (
-	"log"
-	"sync/atomic"
-)
+import "log"
 
 // DefaultLogger is the implementation for a Logger using golang log.
 type DefaultLogger struct {
-	enable int32
+	enabled bool
 }
 
 func (l *DefaultLogger) EnableLog(enable bool) {
-	i := 0
-	if enable {
-		i = 1
-	}
-	atomic.StoreInt32(&(l.enable), int32(i))
+	l.enabled = enable
 }
 
 func (l *DefaultLogger) IsEnabled() bool {
-	return atomic.LoadInt32(&(l.enable)) != 0
+	return l.enabled
 }
 
 func (l *DefaultLogger) LogModel(event int, line []string, model [][]string) {
+	if !l.enabled {
+		return
+	}
+
 	for _, v := range line {
 		log.Print(v)
 	}
 }
 
 func (l *DefaultLogger) LogEnforce(event int, line string, request *[]interface{}, policies *[]string, result *[]interface{}) {
+	if !l.enabled {
+		return
+	}
+
 	log.Print(line)
 }
 
 func (l *DefaultLogger) LogPolicy(event int, line string, pPolicyFormat []string, gPolicyFormat []string, pPolicy *[]interface{}, gPolicy *[]interface{}) {
+	if !l.enabled {
+		return
+	}
+
 	log.Print(line)
 	if pPolicy != nil {
 		for k, v := range *pPolicy {
@@ -61,6 +66,10 @@ func (l *DefaultLogger) LogPolicy(event int, line string, pPolicyFormat []string
 }
 
 func (l *DefaultLogger) LogRole(event int, line string, role []string) {
+	if !l.enabled {
+		return
+	}
+
 	log.Print(line)
 }
 

--- a/model/assertion.go
+++ b/model/assertion.go
@@ -31,6 +31,8 @@ type Assertion struct {
 	Policy    [][]string
 	PolicyMap map[string]int
 	RM        rbac.RoleManager
+
+	logger *log.Logger
 }
 
 func (ast *Assertion) buildIncrementalRoleLinks(rm rbac.RoleManager, op PolicyOp, rules [][]string) error {
@@ -83,8 +85,11 @@ func (ast *Assertion) buildRoleLinks(rm rbac.RoleManager) error {
 		}
 	}
 
-	//log.LogPrint("Role links for: " + ast.Key)
-	log.LogRole(log.LogTypeLinkRole, "Role links for: " + ast.Key, []string{ast.Key})
+	(*ast.logger).LogRole(log.LogTypeLinkRole, "Role links for: "+ast.Key, []string{ast.Key})
 
 	return ast.RM.PrintRoles()
+}
+
+func (ast *Assertion) setLogger(logger log.Logger) {
+	ast.logger = &logger
 }

--- a/model/policy.go
+++ b/model/policy.go
@@ -56,10 +56,10 @@ func (model Model) BuildRoleLinks(rm rbac.RoleManager) error {
 
 // PrintPolicy prints the policy to log.
 func (model Model) PrintPolicy() {
-	if !log.GetLogger().IsEnabled() {
+	if !model.GetLogger().IsEnabled() {
 		return
 	}
-	//log.LogPrint("Policy:")
+
 	var (
 		pPolicy       []interface{} // or [][][]string
 		gPolicy       []interface{}
@@ -70,16 +70,14 @@ func (model Model) PrintPolicy() {
 	for _, ast := range model["p"] {
 		pPolicyFormat = append(pPolicyFormat, ast.Value)
 		pPolicy = append(pPolicy, ast.Policy)
-		//log.LogPrint(key, ": ", ast.Value, ": ", ast.Policy)
 	}
 
 	for _, ast := range model["g"] {
 		gPolicyFormat = append(gPolicyFormat, ast.Value)
 		gPolicy = append(gPolicy, ast.Policy)
-		//log.LogPrint(key, ": ", ast.Value, ": ", ast.Policy)
 	}
 
-	log.LogPolicy(log.LogTypePrintPolicy, "Policy: ", pPolicyFormat, gPolicyFormat, &pPolicy, &gPolicy)
+	model.GetLogger().LogPolicy(log.LogTypePrintPolicy, "Policy: ", pPolicyFormat, gPolicyFormat, &pPolicy, &gPolicy)
 }
 
 // ClearPolicy clears all current policy.

--- a/model_test.go
+++ b/model_test.go
@@ -17,6 +17,7 @@ package casbin
 import (
 	"testing"
 
+	"github.com/casbin/casbin/v2/log"
 	fileadapter "github.com/casbin/casbin/v2/persist/file-adapter"
 	"github.com/casbin/casbin/v2/rbac"
 	defaultrolemanager "github.com/casbin/casbin/v2/rbac/default-role-manager"
@@ -348,6 +349,7 @@ func (rm *testCustomRoleManager) GetUsers(name string, domain ...string) ([]stri
 	return []string{}, nil
 }
 func (rm *testCustomRoleManager) PrintRoles() error { return nil }
+func (rm *testCustomRoleManager) SetLogger(logger log.Logger) {}
 
 func TestRBACModelWithCustomRoleManager(t *testing.T) {
 	e, _ := NewEnforcer("examples/rbac_model.conf", "examples/rbac_policy.csv")

--- a/rbac/role_manager.go
+++ b/rbac/role_manager.go
@@ -14,6 +14,8 @@
 
 package rbac
 
+import "github.com/casbin/casbin/v2/log"
+
 // RoleManager provides interface to define the operations for managing roles.
 type RoleManager interface {
 	// Clear clears all stored data and resets the role manager to the initial state.
@@ -35,4 +37,6 @@ type RoleManager interface {
 	GetUsers(name string, domain ...string) ([]string, error)
 	// PrintRoles prints all the roles to log.
 	PrintRoles() error
+	// SetLogger sets role manager's logger.
+	SetLogger(logger log.Logger)
 }


### PR DESCRIPTION
- Fix print stdout log without control.
- Change global logger to enforcer. Every enforcer as well as its role manager and model could use its own logger.

- Fix: https://github.com/casbin/casbin/issues/629