### PR TITLE
fix: LoadModel concurrency

### DIFF
--- a/enforcer_synced.go
+++ b/enforcer_synced.go
@@ -92,6 +92,13 @@ func (e *SyncedEnforcer) SetWatcher(watcher persist.Watcher) error {
 	return watcher.SetUpdateCallback(func(string) { _ = e.LoadPolicy() })
 }
 
+// LoadModel reloads the model from the model CONF file.
+func (e *SyncedEnforcer) LoadModel() error {
+	e.m.Lock()
+	defer e.m.Unlock()
+	return e.Enforcer.LoadModel()
+}
+
 // ClearPolicy clears all policy.
 func (e *SyncedEnforcer) ClearPolicy() {
 	e.m.Lock()


### PR DESCRIPTION
The SyncedEnforcer is used on the condition of concurrency, so a lock is needed for preventing data race. We use a read-write lock for better performance. Cause LoadModel is the read action, so I called m.Lock() instead of RLock(), after read operation, release the lock. Model is used to parse the policy, so it is nessessary to call LoadPolicy after LoadModel.

Fix: https://github.com/casbin/casbin/issues/639