### PR TITLE
docs: update import path in README.md to v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ What Casbin does NOT do:
 ## Installation
 
 ```
-go get github.com/casbin/casbin
+go get github.com/casbin/casbin/v2
 ```
 
 ## Documentation


### PR DESCRIPTION
This updates the installation path to v2, and adds "GO111MODULE=on" to enable use of go modules by default.