### PR TITLE
fix: add missing functions to the synced enforcer

### DIFF
--- a/enforcer_synced.go
+++ b/enforcer_synced.go
@@ -297,6 +297,15 @@ func (e *SyncedEnforcer) AddPolicy(params ...interface{}) (bool, error) {
 	return e.Enforcer.AddPolicy(params...)
 }
 
+// AddPolicies adds authorization rules to the current policy.
+// If the rule already exists, the function returns false for the corresponding rule and the rule will not be added.
+// Otherwise the function returns true for the corresponding rule by adding the new rule.
+func (e *SyncedEnforcer) AddPolicies(rules [][]string) (bool, error) {
+	e.m.Lock()
+	defer e.m.Unlock()
+	return e.Enforcer.AddPolicies(rules)
+}
+
 // AddNamedPolicy adds an authorization rule to the current named policy.
 // If the rule already exists, the function returns false and the rule will not be added.
 // Otherwise the function returns true by adding the new rule.
@@ -306,11 +315,53 @@ func (e *SyncedEnforcer) AddNamedPolicy(ptype string, params ...interface{}) (bo
 	return e.Enforcer.AddNamedPolicy(ptype, params...)
 }
 
+// AddNamedPolicies adds authorization rules to the current named policy.
+// If the rule already exists, the function returns false for the corresponding rule and the rule will not be added.
+// Otherwise the function returns true for the corresponding by adding the new rule.
+func (e *SyncedEnforcer) AddNamedPolicies(ptype string, rules [][]string) (bool, error) {
+	e.m.Lock()
+	defer e.m.Unlock()
+	return e.Enforcer.AddNamedPolicies(ptype, rules)
+}
+
 // RemovePolicy removes an authorization rule from the current policy.
 func (e *SyncedEnforcer) RemovePolicy(params ...interface{}) (bool, error) {
 	e.m.Lock()
 	defer e.m.Unlock()
 	return e.Enforcer.RemovePolicy(params...)
+}
+
+// UpdatePolicy updates an authorization rule from the current policy.
+func (e *SyncedEnforcer) UpdatePolicy(oldPolicy []string, newPolicy []string) (bool, error) {
+	e.m.Lock()
+	defer e.m.Unlock()
+	return e.Enforcer.UpdatePolicy(oldPolicy, newPolicy)
+}
+
+func (e *SyncedEnforcer) UpdateNamedPolicy(ptype string, p1 []string, p2 []string) (bool, error) {
+	e.m.Lock()
+	defer e.m.Unlock()
+	return e.Enforcer.UpdateNamedPolicy(ptype, p1, p2)
+}
+
+// UpdatePolicies updates authorization rules from the current policies.
+func (e *SyncedEnforcer) UpdatePolicies(oldPolices [][]string, newPolicies [][]string) (bool, error) {
+	e.m.Lock()
+	defer e.m.Unlock()
+	return e.Enforcer.UpdatePolicies(oldPolices, newPolicies)
+}
+
+func (e *SyncedEnforcer) UpdateNamedPolicies(ptype string, p1 [][]string, p2 [][]string) (bool, error) {
+	e.m.Lock()
+	defer e.m.Unlock()
+	return e.Enforcer.UpdateNamedPolicies(ptype, p1, p2)
+}
+
+// RemovePolicies removes authorization rules from the current policy.
+func (e *SyncedEnforcer) RemovePolicies(rules [][]string) (bool, error) {
+	e.m.Lock()
+	defer e.m.Unlock()
+	return e.Enforcer.RemovePolicies(rules)
 }
 
 // RemoveFilteredPolicy removes an authorization rule from the current policy, field filters can be specified.
@@ -325,6 +376,13 @@ func (e *SyncedEnforcer) RemoveNamedPolicy(ptype string, params ...interface{}) 
 	e.m.Lock()
 	defer e.m.Unlock()
 	return e.Enforcer.RemoveNamedPolicy(ptype, params...)
+}
+
+// RemoveNamedPolicies removes authorization rules from the current named policy.
+func (e *SyncedEnforcer) RemoveNamedPolicies(ptype string, rules [][]string) (bool, error) {
+	e.m.Lock()
+	defer e.m.Unlock()
+	return e.Enforcer.RemoveNamedPolicies(ptype, rules)
 }
 
 // RemoveFilteredNamedPolicy removes an authorization rule from the current named policy, field filters can be specified.
@@ -357,6 +415,15 @@ func (e *SyncedEnforcer) AddGroupingPolicy(params ...interface{}) (bool, error) 
 	return e.Enforcer.AddGroupingPolicy(params...)
 }
 
+// AddGroupingPolicies adds role inheritance rulea to the current policy.
+// If the rule already exists, the function returns false for the corresponding policy rule and the rule will not be added.
+// Otherwise the function returns true for the corresponding policy rule by adding the new rule.
+func (e *SyncedEnforcer) AddGroupingPolicies(rules [][]string) (bool, error) {
+	e.m.Lock()
+	defer e.m.Unlock()
+	return e.Enforcer.AddGroupingPolicies(rules)
+}
+
 // AddNamedGroupingPolicy adds a named role inheritance rule to the current policy.
 // If the rule already exists, the function returns false and the rule will not be added.
 // Otherwise the function returns true by adding the new rule.
@@ -366,11 +433,27 @@ func (e *SyncedEnforcer) AddNamedGroupingPolicy(ptype string, params ...interfac
 	return e.Enforcer.AddNamedGroupingPolicy(ptype, params...)
 }
 
+// AddNamedGroupingPolicies adds named role inheritance rules to the current policy.
+// If the rule already exists, the function returns false for the corresponding policy rule and the rule will not be added.
+// Otherwise the function returns true for the corresponding policy rule by adding the new rule.
+func (e *SyncedEnforcer) AddNamedGroupingPolicies(ptype string, rules [][]string) (bool, error) {
+	e.m.Lock()
+	defer e.m.Unlock()
+	return e.Enforcer.AddNamedGroupingPolicies(ptype, rules)
+}
+
 // RemoveGroupingPolicy removes a role inheritance rule from the current policy.
 func (e *SyncedEnforcer) RemoveGroupingPolicy(params ...interface{}) (bool, error) {
 	e.m.Lock()
 	defer e.m.Unlock()
 	return e.Enforcer.RemoveGroupingPolicy(params...)
+}
+
+// RemoveGroupingPolicies removes role inheritance rules from the current policy.
+func (e *SyncedEnforcer) RemoveGroupingPolicies(rules [][]string) (bool, error) {
+	e.m.Lock()
+	defer e.m.Unlock()
+	return e.Enforcer.RemoveGroupingPolicies(rules)
 }
 
 // RemoveFilteredGroupingPolicy removes a role inheritance rule from the current policy, field filters can be specified.
@@ -387,6 +470,25 @@ func (e *SyncedEnforcer) RemoveNamedGroupingPolicy(ptype string, params ...inter
 	return e.Enforcer.RemoveNamedGroupingPolicy(ptype, params...)
 }
 
+// RemoveNamedGroupingPolicies removes role inheritance rules from the current named policy.
+func (e *SyncedEnforcer) RemoveNamedGroupingPolicies(ptype string, rules [][]string) (bool, error) {
+	e.m.Lock()
+	defer e.m.Unlock()
+	return e.Enforcer.RemoveNamedGroupingPolicies(ptype, rules)
+}
+
+func (e *SyncedEnforcer) UpdateGroupingPolicy(oldRule []string, newRule []string) (bool, error) {
+	e.m.Lock()
+	defer e.m.Unlock()
+	return e.Enforcer.UpdateGroupingPolicy(oldRule, newRule)
+}
+
+func (e *SyncedEnforcer) UpdateNamedGroupingPolicy(ptype string, oldRule []string, newRule []string) (bool, error) {
+	e.m.Lock()
+	defer e.m.Unlock()
+	return e.Enforcer.UpdateNamedGroupingPolicy(ptype, oldRule, newRule)
+}
+
 // RemoveFilteredNamedGroupingPolicy removes a role inheritance rule from the current named policy, field filters can be specified.
 func (e *SyncedEnforcer) RemoveFilteredNamedGroupingPolicy(ptype string, fieldIndex int, fieldValues ...string) (bool, error) {
 	e.m.Lock()
@@ -399,83 +501,4 @@ func (e *SyncedEnforcer) AddFunction(name string, function govaluate.ExpressionF
 	e.m.Lock()
 	defer e.m.Unlock()
 	e.Enforcer.AddFunction(name, function)
-}
-
-// AddGroupingPolicies adds role inheritance rulea to the current policy.
-// If the rule already exists, the function returns false for the corresponding policy rule and the rule will not be added.
-// Otherwise the function returns true for the corresponding policy rule by adding the new rule.
-func (e *SyncedEnforcer) AddGroupingPolicies(rules [][]string) (bool, error) {
-	e.m.Lock()
-	defer e.m.Unlock()
-	return e.Enforcer.AddGroupingPolicies(rules)
-}
-
-// AddNamedGroupingPolicies adds named role inheritance rules to the current policy.
-// If the rule already exists, the function returns false for the corresponding policy rule and the rule will not be added.
-// Otherwise the function returns true for the corresponding policy rule by adding the new rule.
-func (e *SyncedEnforcer) AddNamedGroupingPolicies(ptype string, rules [][]string) (bool, error) {
-	e.m.Lock()
-	defer e.m.Unlock()
-	return e.Enforcer.AddNamedGroupingPolicies(ptype, rules)
-}
-
-// AddPolicies adds authorization rules to the current policy.
-// If the rule already exists, the function returns false for the corresponding rule and the rule will not be added.
-// Otherwise the function returns true for the corresponding rule by adding the new rule.
-func (e *SyncedEnforcer) AddPolicies(rules [][]string) (bool, error) {
-	e.m.Lock()
-	defer e.m.Unlock()
-	return e.Enforcer.AddPolicies(rules)
-}
-
-// AddNamedPolicies adds authorization rules to the current named policy.
-// If the rule already exists, the function returns false for the corresponding rule and the rule will not be added.
-// Otherwise the function returns true for the corresponding by adding the new rule.
-func (e *SyncedEnforcer) AddNamedPolicies(ptype string, rules [][]string) (bool, error) {
-	e.m.Lock()
-	defer e.m.Unlock()
-	return e.Enforcer.AddNamedPolicies(ptype, rules)
-}
-
-// GetImplicitPermissionsForUser gets implicit permissions for a user or role.
-// Compared to GetPermissionsForUser(), this function retrieves permissions for inherited roles.
-// For example:
-// p, admin, data1, read
-// p, alice, data2, read
-// g, alice, admin
-//
-// GetPermissionsForUser("alice") can only get: [["alice", "data2", "read"]].
-// But GetImplicitPermissionsForUser("alice") will get: [["admin", "data1", "read"], ["alice", "data2", "read"]].
-func (e *SyncedEnforcer) GetImplicitPermissionsForUser(user string, domain ...string) ([][]string, error) {
-	e.m.Lock()
-	defer e.m.Unlock()
-	return e.Enforcer.GetImplicitPermissionsForUser(user, domain...)
-}
-
-// GetImplicitRolesForUser gets implicit roles that a user has.
-// Compared to GetRolesForUser(), this function retrieves indirect roles besides direct roles.
-// For example:
-// g, alice, role:admin
-// g, role:admin, role:user
-//
-// GetRolesForUser("alice") can only get: ["role:admin"].
-// But GetImplicitRolesForUser("alice") will get: ["role:admin", "role:user"].
-func (e *SyncedEnforcer) GetImplicitRolesForUser(name string, domain ...string) ([]string, error) {
-	e.m.Lock()
-	defer e.m.Unlock()
-	return e.Enforcer.GetImplicitRolesForUser(name, domain...)
-}
-
-// GetImplicitUsersForPermission gets implicit users for a permission.
-// For example:
-// p, admin, data1, read
-// p, bob, data1, read
-// g, alice, admin
-//
-// GetImplicitUsersForPermission("data1", "read") will get: ["alice", "bob"].
-// Note: only users will be returned, roles (2nd arg in "g") will be excluded.
-func (e *SyncedEnforcer) GetImplicitUsersForPermission(permission ...string) ([]string, error) {
-	e.m.Lock()
-	defer e.m.Unlock()
-	return e.Enforcer.GetImplicitUsersForPermission(permission...)
 }

--- a/rbac_api_synced.go
+++ b/rbac_api_synced.go
@@ -43,6 +43,14 @@ func (e *SyncedEnforcer) AddRoleForUser(user string, role string, domain ...stri
 	return e.Enforcer.AddRoleForUser(user, role, domain...)
 }
 
+// AddRolesForUser adds roles for a user.
+// Returns false if the user already has the roles (aka not affected).
+func (e *SyncedEnforcer) AddRolesForUser(user string, roles []string, domain ...string) (bool, error) {
+	e.m.Lock()
+	defer e.m.Unlock()
+	return e.Enforcer.AddRolesForUser(user, roles, domain...)
+}
+
 // DeleteRoleForUser deletes a role for a user.
 // Returns false if the user does not have the role (aka not affected).
 func (e *SyncedEnforcer) DeleteRoleForUser(user string, role string, domain ...string) (bool, error) {
@@ -119,4 +127,47 @@ func (e *SyncedEnforcer) HasPermissionForUser(user string, permission ...string)
 	e.m.RLock()
 	defer e.m.RUnlock()
 	return e.Enforcer.HasPermissionForUser(user, permission...)
+}
+
+// GetImplicitRolesForUser gets implicit roles that a user has.
+// Compared to GetRolesForUser(), this function retrieves indirect roles besides direct roles.
+// For example:
+// g, alice, role:admin
+// g, role:admin, role:user
+//
+// GetRolesForUser("alice") can only get: ["role:admin"].
+// But GetImplicitRolesForUser("alice") will get: ["role:admin", "role:user"].
+func (e *SyncedEnforcer) GetImplicitRolesForUser(name string, domain ...string) ([]string, error) {
+	e.m.RLock()
+	defer e.m.RUnlock()
+	return e.Enforcer.GetImplicitRolesForUser(name, domain...)
+}
+
+// GetImplicitPermissionsForUser gets implicit permissions for a user or role.
+// Compared to GetPermissionsForUser(), this function retrieves permissions for inherited roles.
+// For example:
+// p, admin, data1, read
+// p, alice, data2, read
+// g, alice, admin
+//
+// GetPermissionsForUser("alice") can only get: [["alice", "data2", "read"]].
+// But GetImplicitPermissionsForUser("alice") will get: [["admin", "data1", "read"], ["alice", "data2", "read"]].
+func (e *SyncedEnforcer) GetImplicitPermissionsForUser(user string, domain ...string) ([][]string, error) {
+	e.m.RLock()
+	defer e.m.RUnlock()
+	return e.Enforcer.GetImplicitPermissionsForUser(user, domain...)
+}
+
+// GetImplicitUsersForPermission gets implicit users for a permission.
+// For example:
+// p, admin, data1, read
+// p, bob, data1, read
+// g, alice, admin
+//
+// GetImplicitUsersForPermission("data1", "read") will get: ["alice", "bob"].
+// Note: only users will be returned, roles (2nd arg in "g") will be excluded.
+func (e *SyncedEnforcer) GetImplicitUsersForPermission(permission ...string) ([]string, error) {
+	e.m.RLock()
+	defer e.m.RUnlock()
+	return e.Enforcer.GetImplicitUsersForPermission(permission...)
 }


### PR DESCRIPTION
This PR "re-synced" the synced enforcer... Basically:
- add the missing functions to the synced enforcer (there was quite a lot)
- move the functions that belong to the RBAC API into `rbac_api_synced.go`
- re-order some functions in `enforcer_synced.go` to match the `enforcer.go` order (to make it easy to find the missing functions).