### PR TITLE
fix: Unable to add domain matching func

### DIFF
--- a/rbac/default-role-manager/role_manager.go
+++ b/rbac/default-role-manager/role_manager.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/casbin/casbin/v2/errors"
 	"github.com/casbin/casbin/v2/log"
-	"github.com/casbin/casbin/v2/rbac"
 	"github.com/casbin/casbin/v2/util"
 )
 
@@ -45,7 +44,7 @@ type RoleManager struct {
 
 // NewRoleManager is the constructor for creating an instance of the
 // default RoleManager implementation.
-func NewRoleManager(maxHierarchyLevel int) rbac.RoleManager {
+func NewRoleManager(maxHierarchyLevel int) *RoleManager {
 	rm := RoleManager{}
 	rm.roles = &Roles{sync.Map{}}
 	rm.domains = make(map[string]struct{})

--- a/rbac/default-role-manager/role_manager_test.go
+++ b/rbac/default-role-manager/role_manager_test.go
@@ -233,7 +233,7 @@ func TestClear(t *testing.T) {
 
 func TestDomainPatternRole(t *testing.T) {
 	rm := NewRoleManager(10)
-	rm.(*RoleManager).AddDomainMatchingFunc("keyMatch2", util.KeyMatch2)
+	rm.AddDomainMatchingFunc("keyMatch2", util.KeyMatch2)
 
 	_ = rm.AddLink("u1", "g1", "domain1")
 	_ = rm.AddLink("u2", "g1", "domain2")
@@ -263,8 +263,8 @@ func TestDomainPatternRole(t *testing.T) {
 
 func TestAllMatchingFunc(t *testing.T) {
 	rm := NewRoleManager(10)
-	rm.(*RoleManager).AddMatchingFunc("keyMatch2", util.KeyMatch2)
-	rm.(*RoleManager).AddDomainMatchingFunc("keyMatch2", util.KeyMatch2)
+	rm.AddMatchingFunc("keyMatch2", util.KeyMatch2)
+	rm.AddDomainMatchingFunc("keyMatch2", util.KeyMatch2)
 
 	_ = rm.AddLink("/book/:id", "book_group", "*")
 	// Current role inheritance tree after deleting the links:
@@ -277,7 +277,7 @@ func TestAllMatchingFunc(t *testing.T) {
 
 func TestMatchingFuncOrder(t *testing.T) {
 	rm := NewRoleManager(10)
-	rm.(*RoleManager).AddMatchingFunc("regexMatch", util.RegexMatch)
+	rm.AddMatchingFunc("regexMatch", util.RegexMatch)
 
 	_ = rm.AddLink("g\\d+", "root")
 	_ = rm.AddLink("u1", "g1")


### PR DESCRIPTION
This branch fixes casbin/casbin#735

The problem in the code was that the `defaultrolemanager.NewRoleManager` constructor method signature defines a `rbac.RoleManager` instead of a `*RoleManager`.

As side effect, this also involved the import of `rbac`, which is of no use in the `defaultrolemanager` package.

The important aspect to take care of, in fact, is that `defaultrolemanager.RoleManager` adheres to the `rbac.RoleManager`.
This is granted by the language itself.

This modification allows to avoid the type casting.