### PR TITLE
Pull request, as requested

### DIFF
--- a/management_api.go
+++ b/management_api.go
@@ -320,6 +320,7 @@ func (e *Enforcer) RemoveFilteredNamedGroupingPolicy(ptype string, fieldIndex in
 }
 
 // AddFunction adds a customized function.
+// The added function may only return a float64, string, bool, or an array of these three types.
 func (e *Enforcer) AddFunction(name string, function govaluate.ExpressionFunction) {
 	e.fm.AddFunction(name, function)
 }


### PR DESCRIPTION
Within Discuss, I had mentioned a need to document that a function added via AddFunction may only return a float64, bool, string, or an array of these three types.  Yang Luo requested I provide a PR.  This is that PR.