### PR TITLE
fix: duplicate policy type when calling CasbinJsGetPermissionForUser

### DIFF
--- a/frontend.go
+++ b/frontend.go
@@ -25,9 +25,9 @@ func CasbinJsGetPermissionForUser(e IEnforcer, user string) ([]byte, error) {
 	m["m"] = model.ToText()
 	policies := make([][]string, 0)
 	for ptype := range model["p"] {
-		policies = model.GetPolicy("p", ptype)
-		for i := range policies {
-			policies[i] = append([]string{ptype}, policies[i]...)
+		policy := model.GetPolicy("p", ptype)
+		for i := range policy {
+			policies = append(policies, append([]string{ptype}, policy[i]...))
 		}
 	}
 	m["p"] = policies


### PR DESCRIPTION
If you call CasbinJsGetPermissionForUser more than once, the policies are corrupted. Each run duplicate ptype. That is, after the second launch, the policy looks like this:
```
p, p, alice, data1, read
```