### PR TITLE
feat: add `ptype` parameter for WatcherEx methods

### DIFF
--- a/internal_api.go
+++ b/internal_api.go
@@ -58,7 +58,7 @@ func (e *Enforcer) addPolicy(sec string, ptype string, rule []string) (bool, err
 	if e.watcher != nil && e.autoNotifyWatcher {
 		var err error
 		if watcher, ok := e.watcher.(persist.WatcherEx); ok {
-			err = watcher.UpdateForAddPolicy(rule...)
+			err = watcher.UpdateForAddPolicy(ptype, rule...)
 		} else {
 			err = e.watcher.Update()
 		}
@@ -134,7 +134,7 @@ func (e *Enforcer) removePolicy(sec string, ptype string, rule []string) (bool, 
 	if e.watcher != nil && e.autoNotifyWatcher {
 		var err error
 		if watcher, ok := e.watcher.(persist.WatcherEx); ok {
-			err = watcher.UpdateForRemovePolicy(rule...)
+			err = watcher.UpdateForRemovePolicy(ptype, rule...)
 		} else {
 			err = e.watcher.Update()
 		}
@@ -297,11 +297,10 @@ func (e *Enforcer) removeFilteredPolicy(sec string, ptype string, fieldIndex int
 			return ruleRemoved, err
 		}
 	}
-
 	if e.watcher != nil && e.autoNotifyWatcher {
 		var err error
 		if watcher, ok := e.watcher.(persist.WatcherEx); ok {
-			err = watcher.UpdateForRemoveFilteredPolicy(fieldIndex, fieldValues...)
+			err = watcher.UpdateForRemoveFilteredPolicy(ptype, fieldIndex, fieldValues...)
 		} else {
 			err = e.watcher.Update()
 		}

--- a/internal_api.go
+++ b/internal_api.go
@@ -58,7 +58,7 @@ func (e *Enforcer) addPolicy(sec string, ptype string, rule []string) (bool, err
 	if e.watcher != nil && e.autoNotifyWatcher {
 		var err error
 		if watcher, ok := e.watcher.(persist.WatcherEx); ok {
-			err = watcher.UpdateForAddPolicy(ptype, rule...)
+			err = watcher.UpdateForAddPolicy(sec, ptype, rule...)
 		} else {
 			err = e.watcher.Update()
 		}
@@ -134,7 +134,7 @@ func (e *Enforcer) removePolicy(sec string, ptype string, rule []string) (bool, 
 	if e.watcher != nil && e.autoNotifyWatcher {
 		var err error
 		if watcher, ok := e.watcher.(persist.WatcherEx); ok {
-			err = watcher.UpdateForRemovePolicy(ptype, rule...)
+			err = watcher.UpdateForRemovePolicy(sec, ptype, rule...)
 		} else {
 			err = e.watcher.Update()
 		}
@@ -300,7 +300,7 @@ func (e *Enforcer) removeFilteredPolicy(sec string, ptype string, fieldIndex int
 	if e.watcher != nil && e.autoNotifyWatcher {
 		var err error
 		if watcher, ok := e.watcher.(persist.WatcherEx); ok {
-			err = watcher.UpdateForRemoveFilteredPolicy(ptype, fieldIndex, fieldValues...)
+			err = watcher.UpdateForRemoveFilteredPolicy(sec, ptype, fieldIndex, fieldValues...)
 		} else {
 			err = e.watcher.Update()
 		}

--- a/persist/watcher_ex.go
+++ b/persist/watcher_ex.go
@@ -21,13 +21,13 @@ type WatcherEx interface {
 	Watcher
 	// UpdateForAddPolicy calls the update callback of other instances to synchronize their policy.
 	// It is called after Enforcer.AddPolicy()
-	UpdateForAddPolicy(params ...string) error
+	UpdateForAddPolicy(ptype string, params ...string) error
 	// UPdateForRemovePolicy calls the update callback of other instances to synchronize their policy.
 	// It is called after Enforcer.RemovePolicy()
-	UpdateForRemovePolicy(params ...string) error
+	UpdateForRemovePolicy(ptype string, params ...string) error
 	// UpdateForRemoveFilteredPolicy calls the update callback of other instances to synchronize their policy.
 	// It is called after Enforcer.RemoveFilteredNamedGroupingPolicy()
-	UpdateForRemoveFilteredPolicy(fieldIndex int, fieldValues ...string) error
+	UpdateForRemoveFilteredPolicy(ptype string, fieldIndex int, fieldValues ...string) error
 	// UpdateForSavePolicy calls the update callback of other instances to synchronize their policy.
 	// It is called after Enforcer.RemoveFilteredNamedGroupingPolicy()
 	UpdateForSavePolicy(model model.Model) error

--- a/persist/watcher_ex.go
+++ b/persist/watcher_ex.go
@@ -21,13 +21,13 @@ type WatcherEx interface {
 	Watcher
 	// UpdateForAddPolicy calls the update callback of other instances to synchronize their policy.
 	// It is called after Enforcer.AddPolicy()
-	UpdateForAddPolicy(ptype string, params ...string) error
+	UpdateForAddPolicy(sec, ptype string, params ...string) error
 	// UPdateForRemovePolicy calls the update callback of other instances to synchronize their policy.
 	// It is called after Enforcer.RemovePolicy()
-	UpdateForRemovePolicy(ptype string, params ...string) error
+	UpdateForRemovePolicy(sec, ptype string, params ...string) error
 	// UpdateForRemoveFilteredPolicy calls the update callback of other instances to synchronize their policy.
 	// It is called after Enforcer.RemoveFilteredNamedGroupingPolicy()
-	UpdateForRemoveFilteredPolicy(ptype string, fieldIndex int, fieldValues ...string) error
+	UpdateForRemoveFilteredPolicy(sec, ptype string, fieldIndex int, fieldValues ...string) error
 	// UpdateForSavePolicy calls the update callback of other instances to synchronize their policy.
 	// It is called after Enforcer.RemoveFilteredNamedGroupingPolicy()
 	UpdateForSavePolicy(model model.Model) error

--- a/watcher_ex_test.go
+++ b/watcher_ex_test.go
@@ -24,14 +24,14 @@ type SampleWatcherEx struct {
 	SampleWatcher
 }
 
-func (w SampleWatcherEx) UpdateForAddPolicy(params ...string) error {
+func (w SampleWatcherEx) UpdateForAddPolicy(ptype string, params ...string) error {
 	return nil
 }
-func (w SampleWatcherEx) UpdateForRemovePolicy(params ...string) error {
+func (w SampleWatcherEx) UpdateForRemovePolicy(ptype string, params ...string) error {
 	return nil
 }
 
-func (w SampleWatcherEx) UpdateForRemoveFilteredPolicy(fieldIndex int, fieldValues ...string) error {
+func (w SampleWatcherEx) UpdateForRemoveFilteredPolicy(ptype string, fieldIndex int, fieldValues ...string) error {
 	return nil
 }
 
@@ -52,4 +52,8 @@ func TestSetWatcherEx(t *testing.T) {
 	_, _ = e.AddPolicy("admin", "data1", "read")    // calls watcherEx.UpdateForAddPolicy()
 	_, _ = e.RemovePolicy("admin", "data1", "read") // calls watcherEx.UpdateForRemovePolicy()
 	_, _ = e.RemoveFilteredPolicy(1, "data1")       // calls watcherEx.UpdateForRemoveFilteredPolicy()
+	_, _ = e.AddGroupingPolicy("g:admin", "data1")
+	_, _ = e.RemoveGroupingPolicy("g:admin", "data1")
+	_, _ = e.AddGroupingPolicy("g:admin", "data1")
+	_, _ = e.RemoveFilteredGroupingPolicy(1, "data1")
 }

--- a/watcher_ex_test.go
+++ b/watcher_ex_test.go
@@ -24,14 +24,14 @@ type SampleWatcherEx struct {
 	SampleWatcher
 }
 
-func (w SampleWatcherEx) UpdateForAddPolicy(ptype string, params ...string) error {
+func (w SampleWatcherEx) UpdateForAddPolicy(sec, ptype string, params ...string) error {
 	return nil
 }
-func (w SampleWatcherEx) UpdateForRemovePolicy(ptype string, params ...string) error {
+func (w SampleWatcherEx) UpdateForRemovePolicy(sec, ptype string, params ...string) error {
 	return nil
 }
 
-func (w SampleWatcherEx) UpdateForRemoveFilteredPolicy(ptype string, fieldIndex int, fieldValues ...string) error {
+func (w SampleWatcherEx) UpdateForRemoveFilteredPolicy(sec, ptype string, fieldIndex int, fieldValues ...string) error {
 	return nil
 }
 


### PR DESCRIPTION
Fix: https://github.com/casbin/casbin/issues/775

As I mentioned in the issue
https://github.com/casbin/casbin/issues/775
we'd like to have `ptype` parameter in WatcherEx methods. 

This pr is a proposal, and aparently this will break exiting WatcherEx implementation though...