### PR TITLE
fix: get users of role issue

### DIFF
--- a/rbac/default-role-manager/role_manager.go
+++ b/rbac/default-role-manager/role_manager.go
@@ -286,7 +286,7 @@ func (rm *RoleManager) GetUsers(name string, domain ...string) ([]string, error)
 		var names []string
 		for _, domain := range patternDomain {
 			if !rm.hasRole(domain, name) {
-				return nil, errors.ERR_NAME_NOT_FOUND
+				continue
 			}
 
 			domainValue, _ := rm.allDomains.LoadOrStore(domain, &Roles{})


### PR DESCRIPTION
Fix: https://github.com/casbin/casbin/issues/860

Should continue instead of returning an error in `GetUsers` function refering the `GetRoles` function:

https://github.com/casbin/casbin/blob/master/rbac/default-role-manager/role_manager.go#L264

![image](https://user-images.githubusercontent.com/6275608/129156079-008ba6e7-4607-452b-8626-9e3acb83e1d5.png)
