### PR TITLE
Update example with stricter matching

### DIFF
--- a/examples/keymatch_policy.csv
+++ b/examples/keymatch_policy.csv
@@ -4,4 +4,4 @@ p, alice, /alice_data/resource1, POST
 p, bob, /alice_data/resource2, GET
 p, bob, /bob_data/*, POST
 
-p, cathy, /cathy_data, (GET)|(POST)
+p, cathy, /cathy_data, ^(GET|POST)$


### PR DESCRIPTION
In the current example, regex matching will match both POST and the word POSTER because of the structure of the regex. By having them within the first capture group, using the, start of line and end of line token, it will prevent matching words like VIEW and REVIEW from matching