### PR TITLE
fix: breaking change of adapter load policy

### DIFF
--- a/model/policy.go
+++ b/model/policy.go
@@ -340,3 +340,10 @@ func (model Model) GetValuesForFieldInPolicyAllTypes(sec string, fieldIndex int)
 
 	return values
 }
+
+// SyncPolicyIndex syncs model[spec][ptype].PolicyIndex with model[spec][ptype].Policy
+func (model Model) SyncPolicyIndex(spec string, ptype string) {
+	for i, policy := range model[spec][ptype].Policy {
+		model[spec][ptype].PolicyMap[strings.Join(policy, DefaultSep)] = i
+	}
+}


### PR DESCRIPTION
Signed-off-by: abingcbc <abingcbc626@gmail.com>

Fix: https://github.com/casbin/casbin/issues/916

From v2.7.2, casbin started using a map to index policies. But mongo-adapter v2 doesn't load policies into the map.
https://github.com/casbin/mongodb-adapter/blob/v2.1.0/adapter.go#L217
And it was fixed in v3.0.0
https://github.com/casbin/mongodb-adapter/blob/v3.0.0/adapter.go#L194
So this is a breaking change.

One way to work around is manually adding all policies in m[sec][key].Policy into m[sec][key].PolicyMap.

Users can call `SyncPolicyIndex` immediately after calling `LoadPolicy` and it will work well.