### PR TITLE
perf: Put function calls last in example configurations.

### DIFF
--- a/examples/abac_rule_model.conf
+++ b/examples/abac_rule_model.conf
@@ -8,4 +8,4 @@ p = sub_rule, obj, act
 e = some(where (p.eft == allow))
 
 [matchers]
-m = eval(p.sub_rule) && r.obj == p.obj && r.act == p.act
+m = r.obj == p.obj && r.act == p.act && eval(p.sub_rule)

--- a/examples/eval_operator_model.conf
+++ b/examples/eval_operator_model.conf
@@ -8,4 +8,4 @@ p = sub_rule, obj_rule, act
 e = some(where (p.eft == allow))
 
 [matchers]
-m = eval(p.sub_rule) && eval(p.obj_rule) && (p.act == '*' || r.act == p.act)
+m = (p.act == '*' || r.act == p.act) && eval(p.sub_rule) && eval(p.obj_rule)

--- a/examples/glob_model.conf
+++ b/examples/glob_model.conf
@@ -8,4 +8,4 @@ p = sub, obj, act
 e = some(where (p.eft == allow))
 
 [matchers]
-m = r.sub == p.sub && globMatch(r.obj, p.obj) && r.act == p.act
+m = r.sub == p.sub && r.act == p.act && globMatch(r.obj, p.obj)

--- a/examples/ipmatch_model.conf
+++ b/examples/ipmatch_model.conf
@@ -8,4 +8,4 @@ p = sub, obj, act
 e = some(where (p.eft == allow))
 
 [matchers]
-m = ipMatch(r.sub, p.sub) && r.obj == p.obj && r.act == p.act
+m = r.obj == p.obj && r.act == p.act && ipMatch(r.sub, p.sub)

--- a/examples/multiple_policy_definitions_model.conf
+++ b/examples/multiple_policy_definitions_model.conf
@@ -14,6 +14,6 @@ e = some(where (p.eft == allow))
 
 [matchers]
 #RABC
-m = g(r.sub, p.sub) && r.obj == p.obj && r.act == p.act
+m = r.obj == p.obj && r.act == p.act && g(r.sub, p.sub)
 #ABAC
-m2 = eval(p2.sub_rule) && r2.obj == p2.obj && r2.act == p2.act
+m2 = r2.obj == p2.obj && r2.act == p2.act && eval(p2.sub_rule)

--- a/examples/priority_model.conf
+++ b/examples/priority_model.conf
@@ -11,4 +11,4 @@ g = _, _
 e = priority(p.eft) || deny
 
 [matchers]
-m = g(r.sub, p.sub) && r.obj == p.obj && r.act == p.act
+m = r.obj == p.obj && r.act == p.act && g(r.sub, p.sub)

--- a/examples/priority_model_explicit.conf
+++ b/examples/priority_model_explicit.conf
@@ -11,4 +11,4 @@ g = _, _
 e = priority(p.eft) || deny
 
 [matchers]
-m = g(r.sub, p.sub) && r.obj == p.obj && r.act == p.act
+m = r.obj == p.obj && r.act == p.act && g(r.sub, p.sub)

--- a/examples/rbac_model.conf
+++ b/examples/rbac_model.conf
@@ -11,4 +11,4 @@ g = _, _
 e = some(where (p.eft == allow))
 
 [matchers]
-m = g(r.sub, p.sub) && r.obj == p.obj && r.act == p.act
+m = r.obj == p.obj && r.act == p.act && g(r.sub, p.sub)

--- a/examples/rbac_model_in_multi_line.conf
+++ b/examples/rbac_model_in_multi_line.conf
@@ -11,5 +11,5 @@ g = _, _
 e = some(where (p.eft == allow))
 
 [matchers]
-m = g(r.sub, p.sub) && r.obj == p.obj \
- && r.act == p.act
+m = r.obj == p.obj && r.act == p.act \
+  && g(r.sub, p.sub)

--- a/examples/rbac_model_matcher_using_in_op.conf
+++ b/examples/rbac_model_matcher_using_in_op.conf
@@ -11,4 +11,4 @@ g = _, _
 e = some(where (p.eft == allow))
 
 [matchers]
-m = g(r.sub, p.sub) && r.obj == p.obj && r.act == p.act || r.obj in ('data2', 'data3')
+m = r.obj == p.obj && r.act == p.act && g(r.sub, p.sub) || r.obj in ('data2', 'data3')

--- a/examples/rbac_model_matcher_using_in_op_bracket.conf
+++ b/examples/rbac_model_matcher_using_in_op_bracket.conf
@@ -11,4 +11,4 @@ g = _, _
 e = some(where (p.eft == allow))
 
 [matchers]
-m = g(r.sub, p.sub) && r.obj == p.obj && r.act == p.act || r.obj in ['data2', 'data3']
+m = r.obj == p.obj && r.act == p.act && g(r.sub, p.sub) || r.obj in ['data2', 'data3']

--- a/examples/rbac_with_all_pattern_model.conf
+++ b/examples/rbac_with_all_pattern_model.conf
@@ -11,4 +11,4 @@ g = _, _, _
 e = some(where (p.eft == allow))
 
 [matchers]
-m = r.sub == p.sub && g(r.obj, p.obj, r.dom) && r.dom == p.dom && r.act == p.act 
+m = r.sub == p.sub && r.dom == p.dom && r.act == p.act && g(r.obj, p.obj, r.dom)

--- a/examples/rbac_with_deny_model.conf
+++ b/examples/rbac_with_deny_model.conf
@@ -11,4 +11,4 @@ g = _, _
 e = some(where (p.eft == allow)) && !some(where (p.eft == deny))
 
 [matchers]
-m = g(r.sub, p.sub) && r.obj == p.obj && r.act == p.act
+m = r.obj == p.obj && r.act == p.act && g(r.sub, p.sub)

--- a/examples/rbac_with_domain_pattern_model.conf
+++ b/examples/rbac_with_domain_pattern_model.conf
@@ -11,4 +11,4 @@ g = _, _, _
 e = some(where (p.eft == allow))
 
 [matchers]
-m = g(r.sub, p.sub, r.dom) && r.dom == p.dom && r.obj == p.obj && r.act == p.act 
+m = r.dom == p.dom && r.obj == p.obj && r.act == p.act && g(r.sub, p.sub, r.dom)

--- a/examples/rbac_with_domains_model.conf
+++ b/examples/rbac_with_domains_model.conf
@@ -11,4 +11,4 @@ g = _, _, _
 e = some(where (p.eft == allow))
 
 [matchers]
-m = g(r.sub, p.sub, r.dom) && r.dom == p.dom && r.obj == p.obj && r.act == p.act
+m = r.dom == p.dom && r.obj == p.obj && r.act == p.act && g(r.sub, p.sub, r.dom)

--- a/examples/rbac_with_not_deny_model.conf
+++ b/examples/rbac_with_not_deny_model.conf
@@ -11,4 +11,4 @@ g = _, _
 e = !some(where (p.eft == deny))
 
 [matchers]
-m = g(r.sub, p.sub) && r.obj == p.obj && r.act == p.act
+m = r.obj == p.obj && r.act == p.act && g(r.sub, p.sub)

--- a/examples/rbac_with_resource_roles_model.conf
+++ b/examples/rbac_with_resource_roles_model.conf
@@ -12,4 +12,4 @@ g2 = _, _
 e = some(where (p.eft == allow))
 
 [matchers]
-m = g(r.sub, p.sub) && g2(r.obj, p.obj) && r.act == p.act
+m = r.act == p.act && g(r.sub, p.sub) && g2(r.obj, p.obj)

--- a/examples/subject_priority_model.conf
+++ b/examples/subject_priority_model.conf
@@ -11,4 +11,4 @@ g = _, _
 e = subjectPriority(p.eft) || deny
 
 [matchers]
-m = g(r.sub, p.sub) && r.obj == p.obj && r.act == p.act
+m = r.obj == p.obj && r.act == p.act && g(r.sub, p.sub)

--- a/examples/subject_priority_model_with_domain.conf
+++ b/examples/subject_priority_model_with_domain.conf
@@ -11,4 +11,4 @@ g = _, _, _
 e = subjectPriority(p.eft) || deny
 
 [matchers]
-m = g(r.sub, p.sub, r.dom) && r.dom == p.dom && r.obj == p.obj && r.act == p.act
+m = r.dom == p.dom && r.obj == p.obj && r.act == p.act && g(r.sub, p.sub, r.dom)

--- a/frontend_test.go
+++ b/frontend_test.go
@@ -41,8 +41,9 @@ func TestCasbinJsGetPermissionForUser(t *testing.T) {
 		t.Errorf("Test error: %s", err)
 	}
 	expectedModelStr := regexp.MustCompile("\n+").ReplaceAllString(string(expectedModel), "\n")
-	if strings.TrimSpace(received["m"].(string)) != expectedModelStr {
-		t.Errorf("%s supposed to be %s", strings.TrimSpace(received["m"].(string)), expectedModelStr)
+	actualModelStr := received["m"].(string)
+	if actualModelStr != expectedModelStr {
+		t.Errorf("modelStr = %q; want %q", actualModelStr, expectedModelStr)
 	}
 
 	expectedPolicies, err := ioutil.ReadFile("examples/rbac_with_hierarchy_policy.csv")


### PR DESCRIPTION
String comparisons are a *lot* cheaper than govaluate function calls,
so putting them last in the matcher function can save a shocking amount
of CPU time and allocations, while being functionally identical.

This change reorders the example configurations to put function calls
last where applicable, to provide a good example for users to base
their own configuration off of.

The results of a benchmark where I compared the two options:

    g_first:   g(r.sub, p.sub) && r.obj == p.obj && r.act == p.act
    eq_first:  r.obj == p.obj && r.act == p.act && g(r.sub, p.sub)

    Running tool: /usr/local/bin/go test -benchmem -run=^$ -bench ^BenchmarkRBACModelSizes$ github.com/casbin/casbin/v2

    goos: linux
    goarch: amd64
    pkg: github.com/casbin/casbin/v2
    cpu: Intel(R) Core(TM) i7-10750H CPU @ 2.60GHz
    BenchmarkRBACModelSizes/small/g_first-4      14827      79860 ns/op    38767 B/op      874 allocs/op
    BenchmarkRBACModelSizes/small/eq_first-4     28083      42782 ns/op    16938 B/op      395 allocs/op
    BenchmarkRBACModelSizes/medium/g_first-4      1544     774049 ns/op   372522 B/op     8141 allocs/op
    BenchmarkRBACModelSizes/medium/eq_first-4     4285     284674 ns/op   101990 B/op     2572 allocs/op
    BenchmarkRBACModelSizes/large/g_first-4        159    7562438 ns/op  3533126 B/op    80803 allocs/op
    BenchmarkRBACModelSizes/large/eq_first-4       462    2707900 ns/op   943430 B/op    24257 allocs/op
    PASS
    ok   github.com/casbin/casbin/v2 10.320s

This benchmark is currently only local, but I can commit it to the test
suite if desired, so that the difference can be obvious.