### PR TITLE
test: Update test runners to recent versions of Go.

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ 1.11, 1.12, 1.13, 1.14]
+        go: ['1.14', '1.15', '1.16', '1.17']
     steps:
       - uses: actions/checkout@v2
 
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ 1.11, 1.12, 1.13, 1.14]
+        go: ['1.14', '1.15', '1.16', '1.17']
     steps:
       - uses: actions/checkout@v2
 
@@ -43,7 +43,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.14
+          go-version: '1.17'
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2


### PR DESCRIPTION
Only the last two major versions of Go are supported, so the test
runners should be brought up to date. This keeps `1.14` so we maintain
overlap with the previous configuration.

https://go.dev/doc/devel/release#policy