### PR TITLE
fix: seamless role manager replace

### DIFF
--- a/enforcer.go
+++ b/enforcer.go
@@ -563,7 +563,7 @@ func (e *Enforcer) enforce(matcher string, explains *[]string, rvals ...interfac
 	var effect effector.Effect
 	var explainIndex int
 
-	if policyLen := len(e.model["p"][pType].Policy); policyLen != 0 && strings.Contains(expString, pType+"_") {
+	if policyLen := len(e.model["p"][pType].Policy); policyLen != 0 && strings.Contains(expString, pType + "_"){
 		policyEffects = make([]effector.Effect, policyLen)
 		matcherResults = make([]float64, policyLen)
 

--- a/model_test.go
+++ b/model_test.go
@@ -359,7 +359,6 @@ func (rm *testCustomRoleManager) GetAllDomains() ([]string, error) {
 }
 func (rm *testCustomRoleManager) PrintRoles() error           { return nil }
 func (rm *testCustomRoleManager) SetLogger(logger log.Logger) {}
-func (rm *testCustomRoleManager) Copy() rbac.RoleManager      { return &testCustomRoleManager{} }
 
 func TestRBACModelWithCustomRoleManager(t *testing.T) {
 	e, _ := NewEnforcer("examples/rbac_model.conf", "examples/rbac_policy.csv")

--- a/model_test.go
+++ b/model_test.go
@@ -359,6 +359,7 @@ func (rm *testCustomRoleManager) GetAllDomains() ([]string, error) {
 }
 func (rm *testCustomRoleManager) PrintRoles() error           { return nil }
 func (rm *testCustomRoleManager) SetLogger(logger log.Logger) {}
+func (rm *testCustomRoleManager) Copy() rbac.RoleManager      { return &testCustomRoleManager{} }
 
 func TestRBACModelWithCustomRoleManager(t *testing.T) {
 	e, _ := NewEnforcer("examples/rbac_model.conf", "examples/rbac_policy.csv")

--- a/rbac/role_manager.go
+++ b/rbac/role_manager.go
@@ -44,4 +44,6 @@ type RoleManager interface {
 	PrintRoles() error
 	// SetLogger sets role manager's logger.
 	SetLogger(logger log.Logger)
+	// Copy duplicate role manager
+	Copy() RoleManager
 }


### PR DESCRIPTION
This PR for correct rebuild policies with many casbin instances, that uses external watcher for reload

Fix: https://github.com/casbin/casbin/issues/976