### PR TITLE
ci: upgrade golangci-lint-action to v3

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -46,7 +46,7 @@ jobs:
           go-version: '1.17'
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
           version: v1.29
 


### PR DESCRIPTION
fix: https://github.com/casbin/casbin/pull/942#issuecomment-1085848855

Upgrade to v3 as suggested by a member of [golangci/golangci-lint-action](https://github.com/golangci/golangci-lint-action): https://github.com/golangci/golangci-lint-action/issues/434#issuecomment-1086174860