### PR TITLE
feat: Log panic stack

### DIFF
--- a/enforcer.go
+++ b/enforcer.go
@@ -17,6 +17,7 @@ package casbin
 import (
 	"errors"
 	"fmt"
+	"runtime/debug"
 	"strings"
 
 	"github.com/Knetic/govaluate"
@@ -468,7 +469,7 @@ func NewEnforceContext(suffix string) EnforceContext {
 func (e *Enforcer) enforce(matcher string, explains *[]string, rvals ...interface{}) (ok bool, err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			err = fmt.Errorf("panic: %v", r)
+			err = fmt.Errorf("panic: %v\n%s", r, debug.Stack())
 		}
 	}()
 


### PR DESCRIPTION
I've run into a couple of nil pointer exceptions that would have benefited from a stack reference. This simple adds the stack trace to the recovery error.