### PR TITLE
fix: EscapeAssertion should escapes "r[0-9]." instead "r"

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -21,16 +21,13 @@ import (
 	"sync"
 )
 
-var evalReg *regexp.Regexp = regexp.MustCompile(`\beval\((?P<rule>[^)]*)\)`)
+var evalReg = regexp.MustCompile(`\beval\((?P<rule>[^)]*)\)`)
+
+var escapeAssertionRegex = regexp.MustCompile(`\b((r|p)[0-9]*)\.`)
 
 // EscapeAssertion escapes the dots in the assertion, because the expression evaluation doesn't support such variable names.
 func EscapeAssertion(s string) string {
-	//Replace the first dot, because it can't be recognized by the regexp.
-	if strings.HasPrefix(s, "r") || strings.HasPrefix(s, "p") {
-		s = strings.Replace(s, ".", "_", 1)
-	}
-	var regex = regexp.MustCompile(`(\|| |=|\)|\(|&|<|>|,|\+|-|!|\*|\/)((r|p)[0-9]*)\.`)
-	s = regex.ReplaceAllStringFunc(s, func(m string) string {
+	s = escapeAssertionRegex.ReplaceAllStringFunc(s, func(m string) string {
 		return strings.Replace(m, ".", "_", 1)
 	})
 	return s

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -29,8 +29,13 @@ func testEscapeAssertion(t *testing.T, s string, res string) {
 }
 
 func TestEscapeAssertion(t *testing.T) {
+	testEscapeAssertion(t, "r_sub == r_obj.value", "r_sub == r_obj.value")
+	testEscapeAssertion(t, "p_sub == r_sub.value", "p_sub == r_sub.value")
+	testEscapeAssertion(t, "r.attr.value == p.attr", "r_attr.value == p_attr")
 	testEscapeAssertion(t, "r.attr.value == p.attr", "r_attr.value == p_attr")
 	testEscapeAssertion(t, "r.attp.value || p.attr", "r_attp.value || p_attr")
+	testEscapeAssertion(t, "r2.attr.value == p2.attr", "r2_attr.value == p2_attr")
+	testEscapeAssertion(t, "r2.attp.value || p2.attr", "r2_attp.value || p2_attr")
 	testEscapeAssertion(t, "r.attp.value &&p.attr", "r_attp.value &&p_attr")
 	testEscapeAssertion(t, "r.attp.value >p.attr", "r_attp.value >p_attr")
 	testEscapeAssertion(t, "r.attp.value <p.attr", "r_attp.value <p_attr")


### PR DESCRIPTION
Signed-off-by: tangyang9464 <tangyang9464@163.com>

Similar for Java: https://github.com/casbin/jcasbin/pull/268