### PR TITLE
feat: support domain matching when getting permissions

### DIFF
--- a/examples/rbac_with_domain_pattern_policy.csv
+++ b/examples/rbac_with_domain_pattern_policy.csv
@@ -2,6 +2,7 @@ p, admin, domain1, data1, read
 p, admin, domain1, data1, write
 p, admin, domain2, data2, read
 p, admin, domain2, data2, write
+p, admin, *, data3, read
 
 g, alice, admin, *
 g, bob, admin, domain2


### PR DESCRIPTION
fix: https://github.com/casbin/casbin/issues/969

## How it works
`GetImplicitPermissionsForUser` depends on `GetFilteredPolicies` to query permissions. But when `enforcer` gets filtered policies, it doesn't support domain matching.
So there are main changes in this PR:
1. Make `match` of role manager public and reuse this function for domain matching when getting policies.
2. Add a new function `GetFilteredPolicyWithDomainMatching` for the user requirements mentioned in
https://github.com/casbin/casbin/issues/969.
4. Unit tests.