### PR TITLE
fix: use Github Action for semantic pr validation

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -35,6 +35,14 @@ jobs:
       - name: Run go test bench
         run:  make benchmark
 
+  semantic-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate PR title
+        uses: amannn/action-semantic-pull-request@v4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  
   lint:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
temporarily fix #993 by switch to gh-Action validation

Test pr: [url](https://github.com/JalinWang/casbin/runs/6114876798?check_suite_focus=true)

But this patch need to be applied to each repo :(