### PR TITLE
feat: Enforcer.SetWatcher supports WatcherEx's customized callback.

### DIFF
--- a/enforcer.go
+++ b/enforcer.go
@@ -252,7 +252,13 @@ func (e *Enforcer) SetAdapter(adapter persist.Adapter) {
 // SetWatcher sets the current watcher.
 func (e *Enforcer) SetWatcher(watcher persist.Watcher) error {
 	e.watcher = watcher
-	return watcher.SetUpdateCallback(func(string) { _ = e.LoadPolicy() })
+	if _, ok := e.watcher.(persist.WatcherEx); ok {
+		// The callback of WatcherEx has no generic implementation.
+		return nil
+	} else {
+		// In case the Watcher wants to use a customized callback function, call `SetUpdateCallback` after `SetWatcher`.
+		return watcher.SetUpdateCallback(func(string) { _ = e.LoadPolicy() })
+	}
 }
 
 // GetRoleManager gets the current role manager.

--- a/enforcer_synced.go
+++ b/enforcer_synced.go
@@ -91,8 +91,7 @@ func (e *SyncedEnforcer) StopAutoLoadPolicy() {
 func (e *SyncedEnforcer) SetWatcher(watcher persist.Watcher) error {
 	e.m.Lock()
 	defer e.m.Unlock()
-	e.watcher = watcher
-	return watcher.SetUpdateCallback(func(string) { _ = e.LoadPolicy() })
+	return e.Enforcer.SetWatcher(watcher)
 }
 
 // LoadModel reloads the model from the model CONF file.


### PR DESCRIPTION
As mentioned [here](https://github.com/casbin/redis-watcher/issues/26#issuecomment-1111698719), the `SetWatcher` needs to keep WatcherEx's customized callback.

This is a part of fixing for https://github.com/casbin/casbin/issues/999.

A flaw: There's no way to check whether the callback is set due to the limitation of the `WatcherEx ` interface.