### PR TITLE
feat: add HasPolicyEx() API to determine the policy exist with an error 

### DIFF
--- a/model/model.go
+++ b/model/model.go
@@ -71,6 +71,8 @@ func (model Model) AddDef(sec string, key string, value string) bool {
 		for i := range ast.Tokens {
 			ast.Tokens[i] = key + "_" + strings.TrimSpace(ast.Tokens[i])
 		}
+	} else if sec == "g" {
+		ast.Tokens = strings.Split(ast.Value, ",")
 	} else {
 		ast.Value = util.RemoveComments(util.EscapeAssertion(ast.Value))
 	}

--- a/model/policy.go
+++ b/model/policy.go
@@ -15,6 +15,7 @@
 package model
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -123,6 +124,30 @@ func (model Model) GetFilteredPolicy(sec string, ptype string, fieldIndex int, f
 	}
 
 	return res
+}
+
+// HasPolicyEx determines whether a model has the specified policy rule with error.
+func (model Model) HasPolicyEx(sec string, ptype string, rule []string) (bool, error) {
+	assertion := model[sec][ptype]
+	switch sec {
+	case "p":
+		if len(rule) != len(assertion.Tokens) {
+			return false, fmt.Errorf(
+				"invalid policy rule size: expected %d, got %d, rule: %v",
+				len(model["p"][ptype].Tokens),
+				len(rule),
+				rule)
+		}
+	case "g":
+		if len(rule) < len(assertion.Tokens) {
+			return false, fmt.Errorf(
+				"invalid policy rule size: expected %d, got %d, rule: %v",
+				len(model["g"][ptype].Tokens),
+				len(rule),
+				rule)
+		}
+	}
+	return model.HasPolicy(sec, ptype, rule), nil
 }
 
 // HasPolicy determines whether a model has the specified policy rule.

--- a/persist/adapter.go
+++ b/persist/adapter.go
@@ -44,7 +44,11 @@ func LoadPolicyLine(line string, m model.Model) {
 func LoadPolicyArray(rule []string, m model.Model) {
 	key := rule[0]
 	sec := key[:1]
-	if m.HasPolicy(sec, key, rule[1:]) {
+	ok, err := m.HasPolicyEx(sec, key, rule[1:])
+	if err != nil {
+		return
+	}
+	if ok {
 		return
 	}
 	m.AddPolicy(sec, key, rule[1:])


### PR DESCRIPTION
Fixes: #1016 

Next, we may replace the existing `HasPolicy` call with this and remove check at `Enforce` func.