### PR TITLE
fix: revert lock less when syncing

### DIFF
--- a/enforcer_synced.go
+++ b/enforcer_synced.go
@@ -110,23 +110,9 @@ func (e *SyncedEnforcer) ClearPolicy() {
 
 // LoadPolicy reloads the policy from file/database.
 func (e *SyncedEnforcer) LoadPolicy() error {
-	e.m.RLock()
-	cleanedNewModel := e.model.Copy()
-	e.m.RUnlock()
-	newModel, err := e.prepareNewModel(cleanedNewModel)
-	if err != nil {
-		return err
-	}
-
 	e.m.Lock()
 	defer e.m.Unlock()
-	if e.autoBuildRoleLinks {
-		if err := e.tryBuildingRoleLinksWithModel(newModel); err != nil {
-			return err
-		}
-	}
-	e.model = newModel
-	return nil
+	return e.Enforcer.LoadPolicy()
 }
 
 // LoadFilteredPolicy reloads a filtered policy from file/database.


### PR DESCRIPTION
Reverts casbin/casbin#988

This change can cause races when the management api is used while a new model is being prepared.

Situation:
* T1: Routine 1: loads new model from db into `newModel`
* T2: Routine 2: write change against db and current model
* T3: Routine 1: replace `model` with `newModel`

In this case the write in T2 would not be present until the next reload.

Sadly that brings back the issue that slow policy loading stalls any enforcements. One option might be to use a different lock for such performance critical operation and accept a certain degree of eventual consistency.