### PR TITLE
feat: add FieldIndexMap and constant

### DIFF
--- a/constant/constants.go
+++ b/constant/constants.go
@@ -1,0 +1,30 @@
+// Copyright 2022 The casbin Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package constant
+
+const (
+	DomainIndex   = "dom"
+	SubjectIndex  = "sub"
+	ObjectIndex   = "obj"
+	PriorityIndex = "priority"
+)
+
+const (
+	AllowOverrideEffect   = "some(where (p_eft == allow))"
+	DenyOverrideEffect    = "!some(where (p_eft == deny))"
+	AllowAndDenyEffect    = "some(where (p_eft == allow)) && !some(where (p_eft == deny))"
+	PriorityEffect        = "priority(p_eft) || deny"
+	SubjectPriorityEffect = "subjectPriority(p_eft) || deny"
+)

--- a/effector/default_effector.go
+++ b/effector/default_effector.go
@@ -14,7 +14,11 @@
 
 package effector
 
-import "errors"
+import (
+	"errors"
+
+	"github.com/casbin/casbin/v2/constant"
+)
 
 // DefaultEffector is default effector for Casbin.
 type DefaultEffector struct {
@@ -32,7 +36,7 @@ func (e *DefaultEffector) MergeEffects(expr string, effects []Effect, matches []
 	explainIndex := -1
 
 	switch expr {
-	case "some(where (p_eft == allow))":
+	case constant.AllowOverrideEffect:
 		if matches[policyIndex] == 0 {
 			break
 		}
@@ -42,7 +46,7 @@ func (e *DefaultEffector) MergeEffects(expr string, effects []Effect, matches []
 			explainIndex = policyIndex
 			break
 		}
-	case "!some(where (p_eft == deny))":
+	case constant.DenyOverrideEffect:
 		// only check the current policyIndex
 		if matches[policyIndex] != 0 && effects[policyIndex] == Deny {
 			result = Deny
@@ -53,7 +57,7 @@ func (e *DefaultEffector) MergeEffects(expr string, effects []Effect, matches []
 		if policyIndex == policyLength-1 {
 			result = Allow
 		}
-	case "some(where (p_eft == allow)) && !some(where (p_eft == deny))":
+	case constant.AllowAndDenyEffect:
 		// short-circuit if matched deny rule
 		if matches[policyIndex] != 0 && effects[policyIndex] == Deny {
 			result = Deny
@@ -80,7 +84,7 @@ func (e *DefaultEffector) MergeEffects(expr string, effects []Effect, matches []
 				break
 			}
 		}
-	case "priority(p_eft) || deny", "subjectPriority(p_eft) || deny":
+	case constant.PriorityEffect, constant.SubjectPriorityEffect:
 		// reverse merge, short-circuit may be earlier
 		for i := len(effects) - 1; i >= 0; i-- {
 			if matches[i] == 0 {

--- a/internal_api.go
+++ b/internal_api.go
@@ -15,8 +15,6 @@
 package casbin
 
 import (
-	"fmt"
-
 	Err "github.com/casbin/casbin/v2/errors"
 	"github.com/casbin/casbin/v2/model"
 	"github.com/casbin/casbin/v2/persist"
@@ -373,15 +371,11 @@ func (e *Enforcer) updateFilteredPolicies(sec string, ptype string, newRules [][
 	return ruleChanged, nil
 }
 
-func (e *Enforcer) getDomainIndex(ptype string) int {
-	p := e.model["p"][ptype]
-	pattern := fmt.Sprintf("%s_dom", ptype)
-	index := len(p.Tokens)
-	for i, token := range p.Tokens {
-		if token == pattern {
-			index = i
-			break
-		}
-	}
-	return index
+func (e *Enforcer) GetFieldIndex(ptype string, field string) (int, error) {
+	return e.model.GetFieldIndex(ptype, field)
+}
+
+func (e *Enforcer) SetFieldIndex(ptype string, field string, index int) {
+	assertion := e.model["p"][ptype]
+	assertion.FieldIndexMap[field] = index
 }

--- a/model/assertion.go
+++ b/model/assertion.go
@@ -25,15 +25,15 @@ import (
 // Assertion represents an expression in a section of the model.
 // For example: r = sub, obj, act
 type Assertion struct {
-	Key       string
-	Value     string
-	Tokens    []string
-	Policy    [][]string
-	PolicyMap map[string]int
-	RM        rbac.RoleManager
+	Key           string
+	Value         string
+	Tokens        []string
+	Policy        [][]string
+	PolicyMap     map[string]int
+	RM            rbac.RoleManager
+	FieldIndexMap map[string]int
 
-	logger        log.Logger
-	priorityIndex int
+	logger log.Logger
 }
 
 func (ast *Assertion) buildIncrementalRoleLinks(rm rbac.RoleManager, op PolicyOp, rules [][]string) error {
@@ -93,10 +93,6 @@ func (ast *Assertion) setLogger(logger log.Logger) {
 	ast.logger = logger
 }
 
-func (ast *Assertion) initPriorityIndex() {
-	ast.priorityIndex = -1
-}
-
 func (ast *Assertion) copy() *Assertion {
 	tokens := append([]string(nil), ast.Tokens...)
 	policy := make([][]string, len(ast.Policy))
@@ -115,7 +111,7 @@ func (ast *Assertion) copy() *Assertion {
 		PolicyMap:     policyMap,
 		Tokens:        tokens,
 		Policy:        policy,
-		priorityIndex: ast.priorityIndex,
+		FieldIndexMap: ast.FieldIndexMap,
 	}
 
 	return newAst

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/casbin/casbin/v2/config"
+	"github.com/casbin/casbin/v2/constant"
 )
 
 var (
@@ -140,7 +141,7 @@ func testModelToText(t *testing.T, mData, mExpected string) {
 	expected := map[string]string{
 		"r": "sub, obj, act",
 		"p": "sub, obj, act",
-		"e": "some(where (p_eft == allow))",
+		"e": constant.AllowOverrideEffect,
 		"m": mExpected,
 	}
 	addData := func(ptype string) {

--- a/model/policy.go
+++ b/model/policy.go
@@ -18,6 +18,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/casbin/casbin/v2/constant"
 	"github.com/casbin/casbin/v2/rbac"
 	"github.com/casbin/casbin/v2/util"
 )
@@ -148,11 +149,15 @@ func (model Model) AddPolicy(sec string, ptype string, rule []string) {
 	assertion.Policy = append(assertion.Policy, rule)
 	assertion.PolicyMap[strings.Join(rule, DefaultSep)] = len(model[sec][ptype].Policy) - 1
 
-	if sec == "p" && assertion.priorityIndex >= 0 {
-		if idxInsert, err := strconv.Atoi(rule[assertion.priorityIndex]); err == nil {
+	hasPriority := false
+	if _, ok := assertion.FieldIndexMap[constant.PriorityIndex]; ok {
+		hasPriority = true
+	}
+	if sec == "p" && hasPriority {
+		if idxInsert, err := strconv.Atoi(rule[assertion.FieldIndexMap[constant.PriorityIndex]]); err == nil {
 			i := len(assertion.Policy) - 1
 			for ; i > 0; i-- {
-				idx, err := strconv.Atoi(assertion.Policy[i-1][assertion.priorityIndex])
+				idx, err := strconv.Atoi(assertion.Policy[i-1][assertion.FieldIndexMap[constant.PriorityIndex]])
 				if err != nil {
 					break
 				}


### PR DESCRIPTION
# ChangLog
Some APIs (mostly RBAC APIs) need to obtain the index of variables such as sub, obj, dom, priority, etc. in policy_define. So this PR did the following work
1. add ``FieldIndexMap`` to store index.
2. add ``GetFieldIndex`` and ``SetFieldIndex``, try to get the index with ``sub, obj, dom, priority`` as the default definition named values. If the user does not use the default value, then ``SetFieldIndex`` should be used to set the index

Some other work is adding constants, putting some constants together instead of using strings directly in the code.

related: https://github.com/casbin/casbin/issues/1015#issuecomment-1166218883 #1015 
Signed-off-by: tangyang9464 <tangyang9464@163.com>