### PR TITLE
fix: more APIs are supported in the priority model

### DIFF
--- a/constant/constants.go
+++ b/constant/constants.go
@@ -18,6 +18,7 @@ const (
 	DomainIndex   = "dom"
 	SubjectIndex  = "sub"
 	ObjectIndex   = "obj"
+	ActionIndex   = "act"
 	PriorityIndex = "priority"
 )
 

--- a/internal_api.go
+++ b/internal_api.go
@@ -381,6 +381,14 @@ func (e *Enforcer) GetFieldIndex(ptype string, field string) (int, error) {
 	return e.model.GetFieldIndex(ptype, field)
 }
 
+func (e *Enforcer) GetFieldIndexWithDefault(ptype string, field string, defaultLoc int) int {
+	i, err := e.GetFieldIndex(ptype, field)
+	if i == -1 || err != nil {
+		i = defaultLoc
+	}
+	return i
+}
+
 func (e *Enforcer) SetFieldIndex(ptype string, field string, index int) {
 	assertion := e.model["p"][ptype]
 	assertion.FieldIndexMap[field] = index

--- a/management_api.go
+++ b/management_api.go
@@ -17,6 +17,7 @@ package casbin
 import (
 	"errors"
 	"fmt"
+	"github.com/casbin/casbin/v2/constant"
 	"strings"
 
 	"github.com/Knetic/govaluate"
@@ -25,32 +26,38 @@ import (
 
 // GetAllSubjects gets the list of subjects that show up in the current policy.
 func (e *Enforcer) GetAllSubjects() []string {
-	return e.model.GetValuesForFieldInPolicyAllTypes("p", 0)
+	return e.model.GetValuesForFieldInPolicyAllTypes("p",
+		e.GetFieldIndexWithDefault("p", constant.SubjectIndex, 0))
 }
 
 // GetAllNamedSubjects gets the list of subjects that show up in the current named policy.
 func (e *Enforcer) GetAllNamedSubjects(ptype string) []string {
-	return e.model.GetValuesForFieldInPolicy("p", ptype, 0)
+	return e.model.GetValuesForFieldInPolicy("p", ptype,
+		e.GetFieldIndexWithDefault("p", constant.SubjectIndex, 0))
 }
 
 // GetAllObjects gets the list of objects that show up in the current policy.
 func (e *Enforcer) GetAllObjects() []string {
-	return e.model.GetValuesForFieldInPolicyAllTypes("p", 1)
+	return e.model.GetValuesForFieldInPolicyAllTypes("p",
+		e.GetFieldIndexWithDefault("p", constant.ObjectIndex, 1))
 }
 
 // GetAllNamedObjects gets the list of objects that show up in the current named policy.
 func (e *Enforcer) GetAllNamedObjects(ptype string) []string {
-	return e.model.GetValuesForFieldInPolicy("p", ptype, 1)
+	return e.model.GetValuesForFieldInPolicy("p", ptype,
+		e.GetFieldIndexWithDefault("p", constant.ObjectIndex, 1))
 }
 
 // GetAllActions gets the list of actions that show up in the current policy.
 func (e *Enforcer) GetAllActions() []string {
-	return e.model.GetValuesForFieldInPolicyAllTypes("p", 2)
+	return e.model.GetValuesForFieldInPolicyAllTypes("p",
+		e.GetFieldIndexWithDefault("p", constant.ActionIndex, 2))
 }
 
 // GetAllNamedActions gets the list of actions that show up in the current named policy.
 func (e *Enforcer) GetAllNamedActions(ptype string) []string {
-	return e.model.GetValuesForFieldInPolicy("p", ptype, 2)
+	return e.model.GetValuesForFieldInPolicy("p", ptype,
+		e.GetFieldIndexWithDefault("p", constant.ActionIndex, 2))
 }
 
 // GetAllRoles gets the list of roles that show up in the current policy.
@@ -179,6 +186,11 @@ func (e *Enforcer) HasPolicy(params ...interface{}) bool {
 	return e.HasNamedPolicy("p", params...)
 }
 
+// HasFilteredPolicy determines whether an authorization rule exists, field filters can be specified.
+func (e *Enforcer) HasFilteredPolicy(fieldIndex int, fieldValues ...string) bool {
+	return e.HasFilteredNamedPolicyy("p", fieldIndex, fieldValues...)
+}
+
 // HasNamedPolicy determines whether a named authorization rule exists.
 func (e *Enforcer) HasNamedPolicy(ptype string, params ...interface{}) bool {
 	if strSlice, ok := params[0].([]string); len(params) == 1 && ok {
@@ -191,6 +203,11 @@ func (e *Enforcer) HasNamedPolicy(ptype string, params ...interface{}) bool {
 	}
 
 	return e.model.HasPolicy("p", ptype, policy)
+}
+
+// HasFilteredPolicy determines whether an authorization rule exists, field filters can be specified.
+func (e *Enforcer) HasFilteredNamedPolicyy(ptype string, fieldIndex int, fieldValues ...string) bool {
+	return e.model.HasFilteredPolicy("p", ptype, fieldIndex, fieldValues...)
 }
 
 // AddPolicy adds an authorization rule to the current policy.

--- a/model/policy.go
+++ b/model/policy.go
@@ -157,6 +157,24 @@ func (model Model) HasPolicy(sec string, ptype string, rule []string) bool {
 	return ok
 }
 
+// HasFilteredPolicy determines whether a model has the specified policy rule.
+func (model Model) HasFilteredPolicy(sec string, ptype string, fieldIndex int, fieldValues ...string) bool {
+	for _, rule := range model[sec][ptype].Policy {
+		matched := true
+		for i, fieldValue := range fieldValues {
+			if fieldValue != "" && rule[fieldIndex+i] != fieldValue {
+				matched = false
+				break
+			}
+		}
+
+		if matched {
+			return true
+		}
+	}
+	return false
+}
+
 // HasPolicies determines whether a model has any of the specified policies. If one is found we return true.
 func (model Model) HasPolicies(sec string, ptype string, rules [][]string) bool {
 	for i := 0; i < len(rules); i++ {


### PR DESCRIPTION
fix https://github.com/casbin/casbin/issues/1015#issuecomment-1172308507

I also do a modification on the behavior of `DeletePermission`&`DeletePermissionForUser`: if they are worked in a priority model,  they don't require a priority value in the permission parameters( `DeletePermission("alice", "read")` instead of `DeletePermission(10, "alice", "read")` and `DeletePermissionForUser("alice", "read")` instead of `DeletePermissionForUser("alice", 10, "read")`))
