### PR TITLE
feat(lint): add `golangci.yml` config file

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,46 @@
+linters:
+  disable-all: true
+  enable:
+    - bodyclose
+    - deadcode
+    - depguard
+    - dogsled
+    - dupl
+    - errcheck
+    - exportloopref
+    - funlen
+    - gochecknoinits
+    - goconst
+    - gocritic
+    - gocyclo
+    - gofmt
+    - goimports
+    - gomnd
+    - goprintffuncname
+    - gosec
+    - gosimple
+    - govet
+    - ineffassign
+    - lll
+    - misspell
+    - nakedret
+    - noctx
+    - nolintlint
+    - staticcheck
+    - structcheck
+    - stylecheck
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+    - varcheck
+    - whitespace
+
+run:
+  deadline: 5m
+  modules-download-mode: vendor
+
+linters-settings:
+  lll:
+    line-length: 150
+    tab-width: 1


### PR DESCRIPTION
Close: #1054 

$ golangci-lint run   
```bash          
enforcer.go:178:18: invalid operation: cannot compare e.adapter != nil (operator != not defined on untyped nil) (typecheck)
        if e.adapter != nil && (!ok || ok && !fa.IsFiltered()) {
                        ^
enforcer.go:281:21: invalid operation: cannot compare e.dispatcher != nil (operator != not defined on untyped nil) (typecheck)
        if e.dispatcher != nil && e.autoNotifyDispatcher {
                           ^
enforcer.go:390:18: invalid operation: cannot compare e.watcher != nil (operator != not defined on untyped nil) (typecheck)
        if e.watcher != nil {
                        ^
internal_api.go:30:22: invalid operation: cannot compare e.adapter != nil (operator != not defined on untyped nil) (typecheck)
        return e.adapter != nil && e.autoSave
                            ^
internal_api.go:35:21: invalid operation: cannot compare e.dispatcher != nil (operator != not defined on untyped nil) (typecheck)
        if e.dispatcher != nil && e.autoNotifyDispatcher {
                           ^
internal_api.go:60:18: invalid operation: cannot compare e.watcher != nil (operator != not defined on untyped nil) (typecheck)
        if e.watcher != nil && e.autoNotifyWatcher {
                        ^
internal_api.go:75:21: invalid operation: cannot compare e.dispatcher != nil (operator != not defined on untyped nil) (typecheck)
        if e.dispatcher != nil && e.autoNotifyDispatcher {
                           ^
internal_api.go:100:18: invalid operation: cannot compare e.watcher != nil (operator != not defined on untyped nil) (typecheck)
        if e.watcher != nil && e.autoNotifyWatcher {
                        ^
rbac_api.go:309:21: undeclared name: `defaultrolemanager` (typecheck)
                                matched := rm.(*defaultrolemanager.RoleManager).Match(d, rule[domainIndex])
                                                ^
internal_api.go:22:2: "github.com/casbin/casbin/v2/persist" imported but not used (typecheck)
        "github.com/casbin/casbin/v2/persist"
        ^
management_api.go:18:2: "errors" imported but not used (typecheck)
        "errors"
        ^
rbac_api.go:20:2: "github.com/casbin/casbin/v2/rbac/default-role-manager" imported but not used (typecheck)
        "github.com/casbin/casbin/v2/rbac/default-role-manager"
        ^
persist/persist_test.go:39:10: undeclared name: `casbin` (typecheck)
        e, _ := casbin.NewEnforcer("../examples/basic_model.conf")
                ^
persist/persist_test.go:20:2: "github.com/casbin/casbin/v2" imported but not used (typecheck)
        "github.com/casbin/casbin/v2"
        ^
config/config_test.go:71:46: string `r.sub==p.sub && r.obj==p.obj` has 4 occurrences, make it a constant (goconst)
        if v := config.String("multi1::name"); v != "r.sub==p.sub && r.obj==p.obj" {
                                                    ^
persist/cache/default-cache.go:27:9: indent-error-flow: if block ends with a return statement, so drop this else and outdent its block (move short variable declaration to its own line if necessary) (revive)
        } else {
                return res, nil
        }
persist/cache/default-cache.go:35:9: indent-error-flow: if block ends with a return statement, so drop this else and outdent its block (move short variable declaration to its own line if necessary) (revive)
        } else {
                delete(*c, key)
                return nil
        }
errors/rbac_errors.go:21:2: error-naming: error var ERR_NAME_NOT_FOUND should have name of the form ErrFoo (revive)
        ERR_NAME_NOT_FOUND            = errors.New("error: name does not exist")
        ^
errors/rbac_errors.go:22:2: error-naming: error var ERR_DOMAIN_PARAMETER should have name of the form ErrFoo (revive)
        ERR_DOMAIN_PARAMETER          = errors.New("error: domain should be 1 parameter")
        ^
errors/rbac_errors.go:23:2: error-naming: error var ERR_LINK_NOT_FOUND should have name of the form ErrFoo (revive)
        ERR_LINK_NOT_FOUND            = errors.New("error: link between name1 and name2 does not exist")
        ^
errors/rbac_errors.go:24:2: error-naming: error var ERR_USE_DOMAIN_PARAMETER should have name of the form ErrFoo (revive)
        ERR_USE_DOMAIN_PARAMETER      = errors.New("error: useDomain should be 1 parameter")
        ^
errors/rbac_errors.go:25:2: error-naming: error var INVALID_FIELDVAULES_PARAMETER should have name of the form ErrFoo (revive)
        INVALID_FIELDVAULES_PARAMETER = errors.New("fieldValues requires at least one parameter")
        ^
config/config.go:40:6: exported: type name will be used as config.ConfigInterface by other packages, and that stutters; consider calling this Interface (revive)
type ConfigInterface interface {
     ^
config/config.go:30:2: var-naming: don't use ALL_CAPS in Go names; use CamelCase (revive)
        DEFAULT_SECTION = "default"
        ^
config/config.go:32:2: var-naming: don't use ALL_CAPS in Go names; use CamelCase (revive)
        DEFAULT_COMMENT = []byte{'#'}
        ^
config/config.go:34:2: var-naming: don't use ALL_CAPS in Go names; use CamelCase (revive)
        DEFAULT_COMMENT_SEM = []byte{';'}
        ^
config/config.go:110:11: indent-error-flow: if block ends with a return statement, so drop this else and outdent its block (move short variable declaration to its own line if necessary) (revive)
                        } else {
                                canWrite = false
                        }
```

If you don't configure this file, you won't get these hints.

