### PR TITLE
fix: crashing when len(oldRule) != len(newRule) in UpdateFilteredPolicies()

### DIFF
--- a/internal_api.go
+++ b/internal_api.go
@@ -336,7 +336,7 @@ func (e *Enforcer) updateFilteredPolicies(sec string, ptype string, newRules [][
 		}
 		// For compatibility, because some adapters return oldRules containing ptype, see https://github.com/casbin/xorm-adapter/issues/49
 		for i, oldRule := range oldRules {
-			if len(oldRules[i]) == len(newRules[i])+1 {
+			if len(oldRules[i]) == len(e.model[sec][ptype].Tokens)+1 {
 				oldRules[i] = oldRule[1:]
 			}
 		}


### PR DESCRIPTION
fix: https://github.com/casbin/xorm-adapter/issues/49#issuecomment-1195207543