### PR TITLE
feat: allow missing/existing policies in batch manipulation

### DIFF
--- a/error_test.go
+++ b/error_test.go
@@ -235,7 +235,7 @@ func TestMockAdapterErrors(t *testing.T) {
 		t.Log(err6.Error())
 	}
 
-	removed, err7 := e.RemoveGroupingPolicy("bob", "admin2")
+	removed, err7 := e.RemoveGroupingPolicy("bob", "admin", "domain2")
 	if removed {
 		t.Errorf("removed should be false")
 	}
@@ -271,7 +271,7 @@ func TestMockAdapterErrors(t *testing.T) {
 		t.Log(err9.Error())
 	}
 
-	removed, err10 := e.RemoveFilteredNamedGroupingPolicy("g", 0, "eve")
+	removed, err10 := e.RemoveFilteredNamedGroupingPolicy("g", 0, "alice")
 	if removed {
 		t.Errorf("removed should be false")
 	}

--- a/rbac_api_test.go
+++ b/rbac_api_test.go
@@ -178,8 +178,8 @@ func TestEnforcer_AddRolesForUser(t *testing.T) {
 	e, _ := NewEnforcer("examples/rbac_model.conf", "examples/rbac_policy.csv")
 
 	_, _ = e.AddRolesForUser("alice", []string{"data1_admin", "data2_admin", "data3_admin"})
-	// The "alice" already has "data2_admin" , it will be return false. So "alice" just has "data2_admin".
-	testGetRoles(t, e, []string{"data2_admin"}, "alice")
+	// Although "alice" already has "data2_admin", it will add the remaining two roles.
+	testGetRoles(t, e, []string{"data1_admin", "data2_admin", "data3_admin"}, "alice")
 	// delete role
 	_, _ = e.DeleteRoleForUser("alice", "data2_admin")
 


### PR DESCRIPTION
fix https://github.com/casbin/casbin-core/issues/9 
fix https://github.com/casbin/casbin-pg-adapter/issues/42#issuecomment-1207359836

What's more, it makes sure all functions in `policy.go` have the same behavior regarding to duplication.