### PR TITLE
feat: add management api for replica node in distributed system

### DIFF
--- a/enforcer_interface.go
+++ b/enforcer_interface.go
@@ -145,6 +145,15 @@ type IEnforcer interface {
 	SelfRemoveFilteredPolicy(sec string, ptype string, fieldIndex int, fieldValues ...string) (bool, error)
 	SelfUpdatePolicy(sec string, ptype string, oldRule, newRule []string) (bool, error)
 	SelfUpdatePolicies(sec string, ptype string, oldRules, newRules [][]string) (bool, error)
+
+	/* Management API with autoNotifyWatcher and persist disabled for replica node in distributed system*/
+	AddReplicaPolicy(sec string, ptype string, rule []string) (bool, error)
+	AddReplicaPolicies(sec string, ptype string, rules [][]string) (bool, error)
+	RemoveReplicaPolicy(sec string, ptype string, rule []string) (bool, error)
+	RemoveReplicaPolicies(sec string, ptype string, rules [][]string) (bool, error)
+	RemoveReplicaFilteredPolicy(sec string, ptype string, fieldIndex int, fieldValues ...string) (bool, error)
+	UpdateReplicaPolicy(sec string, ptype string, oldRule, newRule []string) (bool, error)
+	UpdateReplicaPolicies(sec string, ptype string, oldRules, newRules [][]string) (bool, error)
 }
 
 var _ IDistributedEnforcer = &DistributedEnforcer{}

--- a/management_api.go
+++ b/management_api.go
@@ -446,3 +446,31 @@ func (e *Enforcer) SelfUpdatePolicy(sec string, ptype string, oldRule, newRule [
 func (e *Enforcer) SelfUpdatePolicies(sec string, ptype string, oldRules, newRules [][]string) (bool, error) {
 	return e.updatePoliciesWithoutNotify(sec, ptype, oldRules, newRules)
 }
+
+func (e *Enforcer) AddReplicaPolicy(sec string, ptype string, rule []string) (bool, error) {
+	return e.addPolicyWithoutNotifyAndPersist(sec, ptype, rule)
+}
+
+func (e *Enforcer) AddReplicaPolicies(sec string, ptype string, rules [][]string) (bool, error) {
+	return e.addPoliciesWithoutNotifyAndPersist(sec, ptype, rules)
+}
+
+func (e *Enforcer) RemoveReplicaPolicy(sec string, ptype string, rule []string) (bool, error) {
+	return e.removePolicyWithoutNotifyAndPersist(sec, ptype, rule)
+}
+
+func (e *Enforcer) RemoveReplicaPolicies(sec string, ptype string, rules [][]string) (bool, error) {
+	return e.removePoliciesWithoutNotifyAndPersist(sec, ptype, rules)
+}
+
+func (e *Enforcer) RemoveReplicaFilteredPolicy(sec string, ptype string, fieldIndex int, fieldValues ...string) (bool, error) {
+	return e.removeFilteredPolicyWithoutNotifyAndPersist(sec, ptype, fieldIndex, fieldValues)
+}
+
+func (e *Enforcer) UpdateReplicaPolicy(sec string, ptype string, oldRule, newRule []string) (bool, error) {
+	return e.updatePolicyWithoutNotifyAndPersist(sec, ptype, oldRule, newRule)
+}
+
+func (e *Enforcer) UpdateReplicaPolicies(sec string, ptype string, oldRules, newRules [][]string) (bool, error) {
+	return e.updatePoliciesWithoutNotifyAndPersist(sec, ptype, oldRules, newRules)
+}


### PR DESCRIPTION
In distributed system, main node has performed persistence successfully, then main node will notify replica node to sync policies, replica node does not need to perform persistence and message notification。In some cases,  replica node fail to  update policy model if it performs persistence again, for https://github.com/casbin/casbin/issues/1118