### PR TITLE
fix: add UpdateNamedGroupingPolicy() APIs to implement the IEnforcer interface

### DIFF
--- a/enforcer_interface.go
+++ b/enforcer_interface.go
@@ -140,6 +140,8 @@ type IEnforcer interface {
 
 	UpdateGroupingPolicy(oldRule []string, newRule []string) (bool, error)
 	UpdateGroupingPolicies(oldRules [][]string, newRules [][]string) (bool, error)
+	UpdateNamedGroupingPolicy(ptype string, oldRule []string, newRule []string) (bool, error)
+	UpdateNamedGroupingPolicies(ptype string, oldRules [][]string, newRules [][]string) (bool, error)
 
 	/* Management API with autoNotifyWatcher disabled */
 	SelfAddPolicy(sec string, ptype string, rule []string) (bool, error)


### PR DESCRIPTION
Fix: https://github.com/casbin/casbin/issues/1206

Defined missing interfaces.