### PR TITLE
fix: fix AddPolicies()'s bug in SyncedCachedEnforcer

### DIFF
--- a/enforcer_cached_synced.go
+++ b/enforcer_cached_synced.go
@@ -102,7 +102,7 @@ func (e *SyncedCachedEnforcer) AddPolicies(rules [][]string) (bool, error) {
 	if ok, err := e.checkManyAndRemoveCache(rules); !ok {
 		return ok, err
 	}
-	return e.SyncedEnforcer.RemovePolicies(rules)
+	return e.SyncedEnforcer.AddPolicies(rules)
 }
 
 func (e *SyncedCachedEnforcer) RemovePolicy(params ...interface{}) (bool, error) {


### PR DESCRIPTION
Fix: https://github.com/casbin/casbin/issues/1222

fix: change enforcer_cached_synced.go AddPolicies() API in the SyncedEnforcer.RemovePolicies to AddPolicies