### PR TITLE
feat: don't crash if Clear gets called while holding a lock

### DIFF
--- a/enforcer_cached_synced_test.go
+++ b/enforcer_cached_synced_test.go
@@ -38,7 +38,9 @@ func TestSyncCache(t *testing.T) {
 		go func() {
 			_, _ = e.AddPolicy("alice", "data2", "read")
 			testSyncEnforceCache(t, e, "alice", "data2", "read", true)
-			e.InvalidateCache()
+			if e.InvalidateCache() != nil {
+				panic("never reached")
+			}
 			g.Done()
 		}()
 	}

--- a/persist/cache/cache_sync.go
+++ b/persist/cache/cache_sync.go
@@ -29,9 +29,9 @@ func (c *SyncCache) Set(key string, value bool, extra ...interface{}) error {
 	if len(extra) > 0 {
 		ttl = extra[0].(time.Duration)
 	}
-	(*c).Lock()
-	defer (*c).Unlock()
-	(*c).cache[key] = cacheItem{
+	c.Lock()
+	defer c.Unlock()
+	c.cache[key] = cacheItem{
 		value:     value,
 		expiresAt: time.Now().Add(ttl),
 		ttl:       ttl,
@@ -40,16 +40,16 @@ func (c *SyncCache) Set(key string, value bool, extra ...interface{}) error {
 }
 
 func (c *SyncCache) Get(key string) (bool, error) {
-	(*c).RLock()
-	res, ok := (*c).cache[key]
-	(*c).RUnlock()
+	c.RLock()
+	res, ok := c.cache[key]
+	c.RUnlock()
 	if !ok {
 		return false, ErrNoSuchKey
 	} else {
 		if res.ttl > 0 && time.Now().After(res.expiresAt) {
-			(*c).Lock()
-			defer (*c).Unlock()
-			delete((*c).cache, key)
+			c.Lock()
+			defer c.Unlock()
+			delete(c.cache, key)
 			return false, ErrNoSuchKey
 		}
 		return res.value, nil
@@ -57,24 +57,23 @@ func (c *SyncCache) Get(key string) (bool, error) {
 }
 
 func (c *SyncCache) Delete(key string) error {
-	(*c).RLock()
-	_, ok := (*c).cache[key]
-	(*c).RUnlock()
+	c.RLock()
+	_, ok := c.cache[key]
+	c.RUnlock()
 	if !ok {
 		return ErrNoSuchKey
 	} else {
-		(*c).Lock()
-		defer (*c).Unlock()
-		delete((*c).cache, key)
+		c.Lock()
+		defer c.Unlock()
+		delete(c.cache, key)
 		return nil
 	}
 }
 
 func (c *SyncCache) Clear() error {
-	*c = SyncCache{
-		make(DefaultCache),
-		sync.RWMutex{},
-	}
+	c.Lock()
+	c.cache = make(DefaultCache)
+	c.Unlock()
 	return nil
 }
 


### PR DESCRIPTION
In a highly concurrent situation, Clear can be called while a mutex is held, which can cause issues when trying to unlock the mutex.

Fixes #1228 