### PR TITLE
feat: optimize enforce performance by deleting cache in Match

### DIFF
--- a/rbac/default-role-manager/role_manager.go
+++ b/rbac/default-role-manager/role_manager.go
@@ -56,12 +56,12 @@ func (r *Role) removeRole(role *Role) {
 	role.removeUser(r)
 }
 
-//should only be called inside addRole
+// should only be called inside addRole
 func (r *Role) addUser(user *Role) {
 	r.users.Store(user.name, user)
 }
 
-//should only be called inside removeRole
+// should only be called inside removeRole
 func (r *Role) removeUser(user *Role) {
 	r.users.Delete(user.name)
 }
@@ -201,18 +201,14 @@ func (rm *RoleManagerImpl) rebuild() {
 }
 
 func (rm *RoleManagerImpl) Match(str string, pattern string) bool {
-	cacheKey := strings.Join([]string{str, pattern}, "$$")
-	if v, has := rm.matchingFuncCache.Get(cacheKey); has {
-		return v.(bool)
+	if str == pattern {
+		return true
+	}
+
+	if rm.matchingFunc != nil {
+		return rm.matchingFunc(str, pattern)
 	} else {
-		var matched bool
-		if rm.matchingFunc != nil {
-			matched = rm.matchingFunc(str, pattern)
-		} else {
-			matched = str == pattern
-		}
-		rm.matchingFuncCache.Put(cacheKey, matched)
-		return matched
+		return false
 	}
 }
 
@@ -493,7 +489,7 @@ func (dm *DomainManager) rebuild() {
 	})
 }
 
-//Clear clears all stored data and resets the role manager to the initial state.
+// Clear clears all stored data and resets the role manager to the initial state.
 func (dm *DomainManager) Clear() error {
 	dm.rmMap = &sync.Map{}
 	dm.matchingFuncCache = util.NewSyncLRUCache(100)
@@ -512,18 +508,14 @@ func (dm *DomainManager) getDomain(domains ...string) (domain string, err error)
 }
 
 func (dm *DomainManager) Match(str string, pattern string) bool {
-	cacheKey := strings.Join([]string{str, pattern}, "$$")
-	if v, has := dm.matchingFuncCache.Get(cacheKey); has {
-		return v.(bool)
+	if str == pattern {
+		return true
+	}
+
+	if dm.domainMatchingFunc != nil {
+		return dm.domainMatchingFunc(str, pattern)
 	} else {
-		var matched bool
-		if dm.domainMatchingFunc != nil {
-			matched = dm.domainMatchingFunc(str, pattern)
-		} else {
-			matched = str == pattern
-		}
-		dm.matchingFuncCache.Put(cacheKey, matched)
-		return matched
+		return false
 	}
 }
 


### PR DESCRIPTION
fix: https://github.com/casbin/casbin/issues/1236


```golang
package main

import (
	"fmt"
	"log"
	"testing"

	"github.com/casbin/casbin/v2"
)

var e1 *casbin.Enforcer

func init() {
	e, err := casbin.NewEnforcer("examples/rbac_with_domains_model.conf", "examples/rbac_with_domains_policy.csv")
	if err != nil {
		panic(err)
	}

	pPolicies := make([][]string, 0)
	for i := 0; i < 100; i++ {
		pPolicies = append(pPolicies, []string{fmt.Sprintf("user_%d", i), fmt.Sprintf("data_%d", i/10), "read"})
	}

	_, err = e.AddPolicies(pPolicies)
	if err != nil {
		log.Fatal(err)
	}
	e1 = e
}

func BenchmarkRunNoneParallel(b *testing.B) {
	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		_, _ = e1.GetNamedImplicitPermissionsForUser("p", "alice", "domain1")
	}
	b.StopTimer()
}

// Match2
func BenchmarkRunNoneParallel2(b *testing.B) {
	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		_, _ = e1.GetNamedImplicitPermissionsForUser2("p", "alice", "domain1")
	}
	b.StopTimer()
}

func BenchmarkRunParallel(b *testing.B) {
	b.ResetTimer()
	b.RunParallel(func(pb *testing.PB) {
		for pb.Next() {
			_, _ = e1.GetNamedImplicitPermissionsForUser("p", "alice", "domain1")
		}
	})
	b.StopTimer()
}

// Match2
func BenchmarkRunParallel2(b *testing.B) {
	b.ResetTimer()
	b.RunParallel(func(pb *testing.PB) {
		for pb.Next() {
			_, _ = e1.GetNamedImplicitPermissionsForUser2("p", "alice", "domain1")
		}
	})
	b.StopTimer()
}

```



```golang
func (dm *DomainManager) Match(str string, pattern string) bool {
	cacheKey := strings.Join([]string{str, pattern}, "$$")

	if v, has := dm.matchingFuncCache.Get(cacheKey); has {
		return v.(bool)
	} else {
		var matched bool
		if dm.domainMatchingFunc != nil {
			matched = dm.domainMatchingFunc(str, pattern)
		} else {
			matched = str == pattern
		}
		dm.matchingFuncCache.Put(cacheKey, matched)
		return matched
	}
}

func (dm *DomainManager) Match2(str string, pattern string) bool {
	if str == pattern {
		return true
	}

	if dm.domainMatchingFunc != nil {
		return dm.domainMatchingFunc(str, pattern)
	} else {
		return false
	}
}
```

100 policies

```
goos: windows
goarch: amd64
pkg: CasbinDemo
cpu: 12th Gen Intel(R) Core(TM) i9-12900H
BenchmarkRunNoneParallel
BenchmarkRunNoneParallel-20               154140              7721 ns/op
BenchmarkRunNoneParallel2
BenchmarkRunNoneParallel2-20              910068              1362 ns/op
BenchmarkRunParallel
BenchmarkRunParallel-20                    84984             14497 ns/op
BenchmarkRunParallel2
BenchmarkRunParallel2-20                 3703006               358.2 ns/op
PASS
```

1000

```
goos: windows
goarch: amd64
pkg: CasbinDemo
cpu: 12th Gen Intel(R) Core(TM) i9-12900H
BenchmarkRunNoneParallel
BenchmarkRunNoneParallel-20                13658             88185 ns/op
BenchmarkRunNoneParallel2
BenchmarkRunNoneParallel2-20              180202              6081 ns/op
BenchmarkRunParallel
BenchmarkRunParallel-20                     9535            120585 ns/op
BenchmarkRunParallel2
BenchmarkRunParallel2-20                 1000000              1171 ns/op
PASS
```

10000

```
goos: windows
goarch: amd64
pkg: CasbinDemo
cpu: 12th Gen Intel(R) Core(TM) i9-12900H
BenchmarkRunNoneParallel
BenchmarkRunNoneParallel-20                 1141            969498 ns/op
BenchmarkRunNoneParallel2
BenchmarkRunNoneParallel2-20               31956             36568 ns/op
BenchmarkRunParallel
BenchmarkRunParallel-20                      824           1422092 ns/op
BenchmarkRunParallel2
BenchmarkRunParallel2-20                  150696              7079 ns/op
PASS
```

100000

```
goarch: amd64
pkg: CasbinDemo
cpu: 12th Gen Intel(R) Core(TM) i9-12900H
BenchmarkRunNoneParallel
BenchmarkRunNoneParallel-20                   98          11273800 ns/op
BenchmarkRunNoneParallel2
BenchmarkRunNoneParallel2-20                2974            391340 ns/op
BenchmarkRunParallel
BenchmarkRunParallel-20                      100          15039822 ns/op
BenchmarkRunParallel2
BenchmarkRunParallel2-20                   16454             62421 ns/op
PASS
```

1000000

```
goos: windows
goarch: amd64
pkg: CasbinDemo
cpu: 12th Gen Intel(R) Core(TM) i9-12900H
BenchmarkRunNoneParallel
BenchmarkRunNoneParallel-20                   12          95208358 ns/op
BenchmarkRunNoneParallel2
BenchmarkRunNoneParallel2-20                 234           4885141 ns/op
BenchmarkRunParallel
BenchmarkRunParallel-20                       12         143313358 ns/op
BenchmarkRunParallel2
BenchmarkRunParallel2-20                    1411            809199 ns/op
PASS
```

10000000

```
goos: windows
goarch: amd64
pkg: CasbinDemo
cpu: 12th Gen Intel(R) Core(TM) i9-12900H
BenchmarkRunNoneParallel
BenchmarkRunNoneParallel-20                    2         974640350 ns/op
BenchmarkRunNoneParallel2
BenchmarkRunNoneParallel2-20                  22          56539332 ns/op
BenchmarkRunParallel
BenchmarkRunParallel-20                        2        1199198400 ns/op
BenchmarkRunParallel2
BenchmarkRunParallel2-20                     121           9635040 ns/op
PASS
```

