### PR TITLE
fix: add EnforceContext' GetCacheKey()

### DIFF
--- a/enforcer.go
+++ b/enforcer.go
@@ -62,6 +62,10 @@ type EnforceContext struct {
 	MType string
 }
 
+func (e EnforceContext) GetCacheKey() string {
+	return "EnforceContext{" + e.RType + "-" + e.PType + "-" + e.EType + "-" + e.MType + "}"
+}
+
 // NewEnforcer creates an enforcer via file or DB.
 //
 // File:

--- a/enforcer_cached.go
+++ b/enforcer_cached.go
@@ -172,5 +172,3 @@ func GetCacheKey(params ...interface{}) (string, bool) {
 	}
 	return key.String(), true
 }
-
-

--- a/enforcer_cached.go
+++ b/enforcer_cached.go
@@ -172,3 +172,5 @@ func GetCacheKey(params ...interface{}) (string, bool) {
 	}
 	return key.String(), true
 }
+
+

--- a/enforcer_cached_b_test.go
+++ b/enforcer_cached_b_test.go
@@ -180,6 +180,15 @@ func BenchmarkCachedPriorityModel(b *testing.B) {
 	}
 }
 
+func BenchmarkCachedWithEnforceContext(b *testing.B) {
+	e, _ := NewCachedEnforcer("examples/priority_model_enforce_context.conf", "examples/priority_policy_enforce_context.csv", false)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = e.Enforce(EnforceContext{RType: "r2", PType: "p", EType: "e", MType: "m2"}, "alice", "data1")
+	}
+}
+
 func BenchmarkCachedRBACModelMediumParallel(b *testing.B) {
 	e, _ := NewCachedEnforcer("examples/rbac_model.conf", false)
 

--- a/examples/priority_model_enforce_context.conf
+++ b/examples/priority_model_enforce_context.conf
@@ -1,0 +1,16 @@
+[request_definition]
+r = sub, obj, act
+r2 = sub, obj
+
+[policy_definition]
+p = sub, obj, act, eft
+
+[role_definition]
+g = _, _
+
+[policy_effect]
+e = priority(p.eft) || deny
+
+[matchers]
+m = g(r.sub, p.sub) && r.obj == p.obj && r.act == p.act
+m2 = g(r2.sub, p.sub)

--- a/examples/priority_policy_enforce_context.csv
+++ b/examples/priority_policy_enforce_context.csv
@@ -1,0 +1,12 @@
+p, alice, data1, read, allow
+p, data1_deny_group, data1, read, deny
+p, data1_deny_group, data1, write, deny
+p, alice, data1, write, allow
+
+g, alice, data1_deny_group
+
+p, data2_allow_group, data2, read, allow
+p, bob, data2, read, deny
+p, bob, data2, write, deny
+
+g, bob, data2_allow_group


### PR DESCRIPTION
This PR contains a small change to the ``EnforceContext`` type to allow caching enforce requests that have `EnforceContext` as the first parameter. This is to allow the `CachedEnforcer`  and `SyncedCachedEnforcer`  to cache enforce requests with `EnforceContext` as the first parameter.

The `GetCacheKey` already supports generating cache keys for arbitrary types if they implement `CachableParam` so this PR updates the `EnforceContext` so that it becomes a `CachableParam`.

Results (without the changes in this PR):

```
BenchmarkCachedWithEnforceContext-12                              355526              3420 ns/op
````

Results (with the changes in this PR):
```
BenchmarkCachedWithEnforceContext-12                             3807160               284.1 ns/op
````