### PR TITLE
fix: add AddPermissionsForUser to SyncedEnforcer

### DIFF
--- a/enforcer_synced.go
+++ b/enforcer_synced.go
@@ -266,6 +266,11 @@ func (e *SyncedEnforcer) GetAllActions() []string {
 	defer e.m.RUnlock()
 	return e.Enforcer.GetAllActions()
 }
+func (e *SyncedEnforcer) AddPermissionsForUser(user string, permissions ...[]string) (bool, error) {
+	e.m.RLock()
+	defer e.m.RUnlock()
+	return e.Enforcer.AddPermissionsForUser(user, permissions...)
+}
 
 // GetAllNamedActions gets the list of actions that show up in the current named policy.
 func (e *SyncedEnforcer) GetAllNamedActions(ptype string) []string {


### PR DESCRIPTION
the AddPermissionsForUser function is missing from SyncedEnforcer, causing concurrent use errors.