### PR TITLE
fix: LoadPolicyFast perm not work  #1332

### DIFF
--- a/enforcer_synced.go
+++ b/enforcer_synced.go
@@ -157,6 +157,7 @@ func (e *SyncedEnforcer) LoadPolicyFast() error {
 	// reduce the lock range
 	e.m.Lock()
 	defer e.m.Unlock()
+	e.invalidateMatcherMap()
 	e.model = newModel
 	e.rmMap = newRmMap
 	return nil


### PR DESCRIPTION
sense:
Two nodes.  node A add Policy.  node B use LoadPolicyFast() reload data. but not work.
 
reason:

e.matcherMap not clean.  cache data effect verified.