### PR TITLE
fix:concurrent map writes

### DIFF
--- a/enforcer_cached.go
+++ b/enforcer_cached.go
@@ -127,8 +127,8 @@ func (e *CachedEnforcer) RemovePolicies(rules [][]string) (bool, error) {
 }
 
 func (e *CachedEnforcer) getCachedResult(key string) (res bool, err error) {
-	e.locker.RLock()
-	defer e.locker.RUnlock()
+	e.locker.Lock()
+	defer e.locker.Unlock()
 	return e.cache.Get(key)
 }
 


### PR DESCRIPTION
persist/cache/default-cache.go:45

![image](https://github.com/casbin/casbin/assets/53203743/f7798e68-a645-4473-aaea-06c43f98b25a)

this will cause concurrent map writes error