### PR TITLE
feat: update IEnforcer for missing domain methods

### DIFF
--- a/enforcer_interface.go
+++ b/enforcer_interface.go
@@ -86,6 +86,12 @@ type IEnforcer interface {
 	GetPermissionsForUserInDomain(user string, domain string) [][]string
 	AddRoleForUserInDomain(user string, role string, domain string) (bool, error)
 	DeleteRoleForUserInDomain(user string, role string, domain string) (bool, error)
+	GetAllUsersByDomain(domain string) []string
+	DeleteRolesForUserInDomain(user string, domain string) (bool, error)
+	DeleteAllUsersByDomain(domain string) (bool, error)
+	DeleteDomains(domains ...string) (bool, error)
+	GetAllDomains() ([]string, error)
+	GetAllRolesByDomain(domain string) []string
 
 	/* Management API */
 	GetAllSubjects() []string


### PR DESCRIPTION
Add the following missing Domain RBAC API's to the IEnforcer interface:
- DeleteRolesForUserInDomain
- GetAllUsersByDomain
- DeleteAllUsersByDomain
- DeleteDomains
- GetAllDomains
- GetAllRolesByDomain