### PR TITLE
feat: delete grouping policies with index 0 as well in DeleteRole() API

### DIFF
--- a/rbac_api.go
+++ b/rbac_api.go
@@ -114,7 +114,12 @@ func (e *Enforcer) DeleteUser(user string) (bool, error) {
 // Returns false if the role does not exist (aka not affected).
 func (e *Enforcer) DeleteRole(role string) (bool, error) {
 	var err error
-	res1, err := e.RemoveFilteredGroupingPolicy(1, role)
+	res1, err := e.RemoveFilteredGroupingPolicy(0, role)
+	if err != nil {
+		return res1, err
+	}
+
+	res2, err := e.RemoveFilteredGroupingPolicy(1, role)
 	if err != nil {
 		return res1, err
 	}
@@ -123,8 +128,8 @@ func (e *Enforcer) DeleteRole(role string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	res2, err := e.RemoveFilteredPolicy(subIndex, role)
-	return res1 || res2, err
+	res3, err := e.RemoveFilteredPolicy(subIndex, role)
+	return res1 || res2 || res3, err
 }
 
 // DeletePermission deletes a permission.


### PR DESCRIPTION
Fix: https://github.com/casbin/casbin/issues/1363

Delete grouping policies with index 0, when deleting a role, so that role is deleted completely