### PR TITLE
feat: remove Adapter requirement in ContextAdapter

### DIFF
--- a/persist/adapter_context.go
+++ b/persist/adapter_context.go
@@ -22,8 +22,6 @@ import (
 
 // ContextAdapter provides a context-aware interface for Casbin adapters.
 type ContextAdapter interface {
-	Adapter
-
 	// LoadPolicyCtx loads all policy rules from the storage with context.
 	LoadPolicyCtx(ctx context.Context, model model.Model) error
 	// SavePolicyCtx saves all policy rules to the storage with context.


### PR DESCRIPTION
Relate #1349 

Require `Adapter` interface in `ContextAdapter` is meaningless and wierd.