### PR TITLE
feat: add error to some of the APIs

### DIFF
--- a/enforcer_distributed.go
+++ b/enforcer_distributed.go
@@ -34,7 +34,8 @@ func (d *DistributedEnforcer) AddPoliciesSelf(shouldPersist func() bool, sec str
 	if shouldPersist != nil && shouldPersist() {
 		var noExistsPolicy [][]string
 		for _, rule := range rules {
-			hasPolicy, err := d.model.HasPolicy(sec, ptype, rule)
+			var hasPolicy bool
+			hasPolicy, err = d.model.HasPolicy(sec, ptype, rule)
 			if err != nil {
 				return nil, err
 			}
@@ -43,10 +44,8 @@ func (d *DistributedEnforcer) AddPoliciesSelf(shouldPersist func() bool, sec str
 			}
 		}
 
-		if err := d.adapter.(persist.BatchAdapter).AddPolicies(sec, ptype, noExistsPolicy); err != nil {
-			if err.Error() != notImplemented {
-				return nil, err
-			}
+		if err = d.adapter.(persist.BatchAdapter).AddPolicies(sec, ptype, noExistsPolicy); err != nil && err.Error() != notImplemented {
+			return nil, err
 		}
 	}
 
@@ -99,7 +98,7 @@ func (d *DistributedEnforcer) RemoveFilteredPolicySelf(shouldPersist func() bool
 	d.m.Lock()
 	defer d.m.Unlock()
 	if shouldPersist != nil && shouldPersist() {
-		if err := d.adapter.RemoveFilteredPolicy(sec, ptype, fieldIndex, fieldValues...); err != nil {
+		if err = d.adapter.RemoveFilteredPolicy(sec, ptype, fieldIndex, fieldValues...); err != nil {
 			if err.Error() != notImplemented {
 				return nil, err
 			}
@@ -142,7 +141,7 @@ func (d *DistributedEnforcer) UpdatePolicySelf(shouldPersist func() bool, sec st
 	d.m.Lock()
 	defer d.m.Unlock()
 	if shouldPersist != nil && shouldPersist() {
-		err := d.adapter.(persist.UpdatableAdapter).UpdatePolicy(sec, ptype, oldRule, newRule)
+		err = d.adapter.(persist.UpdatableAdapter).UpdatePolicy(sec, ptype, oldRule, newRule)
 		if err != nil {
 			return false, err
 		}
@@ -172,7 +171,7 @@ func (d *DistributedEnforcer) UpdatePoliciesSelf(shouldPersist func() bool, sec 
 	d.m.Lock()
 	defer d.m.Unlock()
 	if shouldPersist != nil && shouldPersist() {
-		err := d.adapter.(persist.UpdatableAdapter).UpdatePolicies(sec, ptype, oldRules, newRules)
+		err = d.adapter.(persist.UpdatableAdapter).UpdatePolicies(sec, ptype, oldRules, newRules)
 		if err != nil {
 			return false, err
 		}

--- a/enforcer_interface.go
+++ b/enforcer_interface.go
@@ -70,7 +70,7 @@ type IEnforcer interface {
 	DeletePermissionForUser(user string, permission ...string) (bool, error)
 	DeletePermissionsForUser(user string) (bool, error)
 	GetPermissionsForUser(user string, domain ...string) ([][]string, error)
-	HasPermissionForUser(user string, permission ...string) bool
+	HasPermissionForUser(user string, permission ...string) (bool, error)
 	GetImplicitRolesForUser(name string, domain ...string) ([]string, error)
 	GetImplicitPermissionsForUser(user string, domain ...string) ([][]string, error)
 	GetImplicitUsersForPermission(permission ...string) ([]string, error)
@@ -94,24 +94,24 @@ type IEnforcer interface {
 	GetAllRolesByDomain(domain string) ([]string, error)
 
 	/* Management API */
-	GetAllSubjects() []string
-	GetAllNamedSubjects(ptype string) []string
-	GetAllObjects() []string
-	GetAllNamedObjects(ptype string) []string
-	GetAllActions() []string
-	GetAllNamedActions(ptype string) []string
-	GetAllRoles() []string
-	GetAllNamedRoles(ptype string) []string
-	GetPolicy() [][]string
-	GetFilteredPolicy(fieldIndex int, fieldValues ...string) [][]string
-	GetNamedPolicy(ptype string) [][]string
-	GetFilteredNamedPolicy(ptype string, fieldIndex int, fieldValues ...string) [][]string
-	GetGroupingPolicy() [][]string
-	GetFilteredGroupingPolicy(fieldIndex int, fieldValues ...string) [][]string
-	GetNamedGroupingPolicy(ptype string) [][]string
-	GetFilteredNamedGroupingPolicy(ptype string, fieldIndex int, fieldValues ...string) [][]string
-	HasPolicy(params ...interface{}) bool
-	HasNamedPolicy(ptype string, params ...interface{}) bool
+	GetAllSubjects() ([]string, error)
+	GetAllNamedSubjects(ptype string) ([]string, error)
+	GetAllObjects() ([]string, error)
+	GetAllNamedObjects(ptype string) ([]string, error)
+	GetAllActions() ([]string, error)
+	GetAllNamedActions(ptype string) ([]string, error)
+	GetAllRoles() ([]string, error)
+	GetAllNamedRoles(ptype string) ([]string, error)
+	GetPolicy() ([][]string, error)
+	GetFilteredPolicy(fieldIndex int, fieldValues ...string) ([][]string, error)
+	GetNamedPolicy(ptype string) ([][]string, error)
+	GetFilteredNamedPolicy(ptype string, fieldIndex int, fieldValues ...string) ([][]string, error)
+	GetGroupingPolicy() ([][]string, error)
+	GetFilteredGroupingPolicy(fieldIndex int, fieldValues ...string) ([][]string, error)
+	GetNamedGroupingPolicy(ptype string) ([][]string, error)
+	GetFilteredNamedGroupingPolicy(ptype string, fieldIndex int, fieldValues ...string) ([][]string, error)
+	HasPolicy(params ...interface{}) (bool, error)
+	HasNamedPolicy(ptype string, params ...interface{}) (bool, error)
 	AddPolicy(params ...interface{}) (bool, error)
 	AddPolicies(rules [][]string) (bool, error)
 	AddNamedPolicy(ptype string, params ...interface{}) (bool, error)
@@ -124,8 +124,8 @@ type IEnforcer interface {
 	RemoveNamedPolicy(ptype string, params ...interface{}) (bool, error)
 	RemoveNamedPolicies(ptype string, rules [][]string) (bool, error)
 	RemoveFilteredNamedPolicy(ptype string, fieldIndex int, fieldValues ...string) (bool, error)
-	HasGroupingPolicy(params ...interface{}) bool
-	HasNamedGroupingPolicy(ptype string, params ...interface{}) bool
+	HasGroupingPolicy(params ...interface{}) (bool, error)
+	HasNamedGroupingPolicy(ptype string, params ...interface{}) (bool, error)
 	AddGroupingPolicy(params ...interface{}) (bool, error)
 	AddGroupingPolicies(rules [][]string) (bool, error)
 	AddGroupingPoliciesEx(rules [][]string) (bool, error)

--- a/enforcer_interface.go
+++ b/enforcer_interface.go
@@ -86,12 +86,12 @@ type IEnforcer interface {
 	GetPermissionsForUserInDomain(user string, domain string) [][]string
 	AddRoleForUserInDomain(user string, role string, domain string) (bool, error)
 	DeleteRoleForUserInDomain(user string, role string, domain string) (bool, error)
-	GetAllUsersByDomain(domain string) []string
+	GetAllUsersByDomain(domain string) ([]string, error)
 	DeleteRolesForUserInDomain(user string, domain string) (bool, error)
 	DeleteAllUsersByDomain(domain string) (bool, error)
 	DeleteDomains(domains ...string) (bool, error)
 	GetAllDomains() ([]string, error)
-	GetAllRolesByDomain(domain string) []string
+	GetAllRolesByDomain(domain string) ([]string, error)
 
 	/* Management API */
 	GetAllSubjects() []string

--- a/enforcer_synced.go
+++ b/enforcer_synced.go
@@ -233,126 +233,126 @@ func (e *SyncedEnforcer) BatchEnforceWithMatcher(matcher string, requests [][]in
 }
 
 // GetAllSubjects gets the list of subjects that show up in the current policy.
-func (e *SyncedEnforcer) GetAllSubjects() []string {
+func (e *SyncedEnforcer) GetAllSubjects() ([]string, error) {
 	e.m.RLock()
 	defer e.m.RUnlock()
 	return e.Enforcer.GetAllSubjects()
 }
 
 // GetAllNamedSubjects gets the list of subjects that show up in the current named policy.
-func (e *SyncedEnforcer) GetAllNamedSubjects(ptype string) []string {
+func (e *SyncedEnforcer) GetAllNamedSubjects(ptype string) ([]string, error) {
 	e.m.RLock()
 	defer e.m.RUnlock()
 	return e.Enforcer.GetAllNamedSubjects(ptype)
 }
 
 // GetAllObjects gets the list of objects that show up in the current policy.
-func (e *SyncedEnforcer) GetAllObjects() []string {
+func (e *SyncedEnforcer) GetAllObjects() ([]string, error) {
 	e.m.RLock()
 	defer e.m.RUnlock()
 	return e.Enforcer.GetAllObjects()
 }
 
 // GetAllNamedObjects gets the list of objects that show up in the current named policy.
-func (e *SyncedEnforcer) GetAllNamedObjects(ptype string) []string {
+func (e *SyncedEnforcer) GetAllNamedObjects(ptype string) ([]string, error) {
 	e.m.RLock()
 	defer e.m.RUnlock()
 	return e.Enforcer.GetAllNamedObjects(ptype)
 }
 
 // GetAllActions gets the list of actions that show up in the current policy.
-func (e *SyncedEnforcer) GetAllActions() []string {
+func (e *SyncedEnforcer) GetAllActions() ([]string, error) {
 	e.m.RLock()
 	defer e.m.RUnlock()
 	return e.Enforcer.GetAllActions()
 }
 
 // GetAllNamedActions gets the list of actions that show up in the current named policy.
-func (e *SyncedEnforcer) GetAllNamedActions(ptype string) []string {
+func (e *SyncedEnforcer) GetAllNamedActions(ptype string) ([]string, error) {
 	e.m.RLock()
 	defer e.m.RUnlock()
 	return e.Enforcer.GetAllNamedActions(ptype)
 }
 
 // GetAllRoles gets the list of roles that show up in the current policy.
-func (e *SyncedEnforcer) GetAllRoles() []string {
+func (e *SyncedEnforcer) GetAllRoles() ([]string, error) {
 	e.m.RLock()
 	defer e.m.RUnlock()
 	return e.Enforcer.GetAllRoles()
 }
 
 // GetAllNamedRoles gets the list of roles that show up in the current named policy.
-func (e *SyncedEnforcer) GetAllNamedRoles(ptype string) []string {
+func (e *SyncedEnforcer) GetAllNamedRoles(ptype string) ([]string, error) {
 	e.m.RLock()
 	defer e.m.RUnlock()
 	return e.Enforcer.GetAllNamedRoles(ptype)
 }
 
 // GetPolicy gets all the authorization rules in the policy.
-func (e *SyncedEnforcer) GetPolicy() [][]string {
+func (e *SyncedEnforcer) GetPolicy() ([][]string, error) {
 	e.m.RLock()
 	defer e.m.RUnlock()
 	return e.Enforcer.GetPolicy()
 }
 
 // GetFilteredPolicy gets all the authorization rules in the policy, field filters can be specified.
-func (e *SyncedEnforcer) GetFilteredPolicy(fieldIndex int, fieldValues ...string) [][]string {
+func (e *SyncedEnforcer) GetFilteredPolicy(fieldIndex int, fieldValues ...string) ([][]string, error) {
 	e.m.RLock()
 	defer e.m.RUnlock()
 	return e.Enforcer.GetFilteredPolicy(fieldIndex, fieldValues...)
 }
 
 // GetNamedPolicy gets all the authorization rules in the named policy.
-func (e *SyncedEnforcer) GetNamedPolicy(ptype string) [][]string {
+func (e *SyncedEnforcer) GetNamedPolicy(ptype string) ([][]string, error) {
 	e.m.RLock()
 	defer e.m.RUnlock()
 	return e.Enforcer.GetNamedPolicy(ptype)
 }
 
 // GetFilteredNamedPolicy gets all the authorization rules in the named policy, field filters can be specified.
-func (e *SyncedEnforcer) GetFilteredNamedPolicy(ptype string, fieldIndex int, fieldValues ...string) [][]string {
+func (e *SyncedEnforcer) GetFilteredNamedPolicy(ptype string, fieldIndex int, fieldValues ...string) ([][]string, error) {
 	e.m.RLock()
 	defer e.m.RUnlock()
 	return e.Enforcer.GetFilteredNamedPolicy(ptype, fieldIndex, fieldValues...)
 }
 
 // GetGroupingPolicy gets all the role inheritance rules in the policy.
-func (e *SyncedEnforcer) GetGroupingPolicy() [][]string {
+func (e *SyncedEnforcer) GetGroupingPolicy() ([][]string, error) {
 	e.m.RLock()
 	defer e.m.RUnlock()
 	return e.Enforcer.GetGroupingPolicy()
 }
 
 // GetFilteredGroupingPolicy gets all the role inheritance rules in the policy, field filters can be specified.
-func (e *SyncedEnforcer) GetFilteredGroupingPolicy(fieldIndex int, fieldValues ...string) [][]string {
+func (e *SyncedEnforcer) GetFilteredGroupingPolicy(fieldIndex int, fieldValues ...string) ([][]string, error) {
 	e.m.RLock()
 	defer e.m.RUnlock()
 	return e.Enforcer.GetFilteredGroupingPolicy(fieldIndex, fieldValues...)
 }
 
 // GetNamedGroupingPolicy gets all the role inheritance rules in the policy.
-func (e *SyncedEnforcer) GetNamedGroupingPolicy(ptype string) [][]string {
+func (e *SyncedEnforcer) GetNamedGroupingPolicy(ptype string) ([][]string, error) {
 	e.m.RLock()
 	defer e.m.RUnlock()
 	return e.Enforcer.GetNamedGroupingPolicy(ptype)
 }
 
 // GetFilteredNamedGroupingPolicy gets all the role inheritance rules in the policy, field filters can be specified.
-func (e *SyncedEnforcer) GetFilteredNamedGroupingPolicy(ptype string, fieldIndex int, fieldValues ...string) [][]string {
+func (e *SyncedEnforcer) GetFilteredNamedGroupingPolicy(ptype string, fieldIndex int, fieldValues ...string) ([][]string, error) {
 	e.m.RLock()
 	defer e.m.RUnlock()
 	return e.Enforcer.GetFilteredNamedGroupingPolicy(ptype, fieldIndex, fieldValues...)
 }
 
 // HasPolicy determines whether an authorization rule exists.
-func (e *SyncedEnforcer) HasPolicy(params ...interface{}) bool {
+func (e *SyncedEnforcer) HasPolicy(params ...interface{}) (bool, error) {
 	e.m.RLock()
 	defer e.m.RUnlock()
 	return e.Enforcer.HasPolicy(params...)
 }
 
 // HasNamedPolicy determines whether a named authorization rule exists.
-func (e *SyncedEnforcer) HasNamedPolicy(ptype string, params ...interface{}) bool {
+func (e *SyncedEnforcer) HasNamedPolicy(ptype string, params ...interface{}) (bool, error) {
 	e.m.RLock()
 	defer e.m.RUnlock()
 	return e.Enforcer.HasNamedPolicy(ptype, params...)
@@ -493,14 +493,14 @@ func (e *SyncedEnforcer) RemoveFilteredNamedPolicy(ptype string, fieldIndex int,
 }
 
 // HasGroupingPolicy determines whether a role inheritance rule exists.
-func (e *SyncedEnforcer) HasGroupingPolicy(params ...interface{}) bool {
+func (e *SyncedEnforcer) HasGroupingPolicy(params ...interface{}) (bool, error) {
 	e.m.RLock()
 	defer e.m.RUnlock()
 	return e.Enforcer.HasGroupingPolicy(params...)
 }
 
 // HasNamedGroupingPolicy determines whether a named role inheritance rule exists.
-func (e *SyncedEnforcer) HasNamedGroupingPolicy(ptype string, params ...interface{}) bool {
+func (e *SyncedEnforcer) HasNamedGroupingPolicy(ptype string, params ...interface{}) (bool, error) {
 	e.m.RLock()
 	defer e.m.RUnlock()
 	return e.Enforcer.HasNamedGroupingPolicy(ptype, params...)

--- a/enforcer_synced_test.go
+++ b/enforcer_synced_test.go
@@ -73,7 +73,10 @@ func TestStopAutoLoadPolicy(t *testing.T) {
 
 func testSyncedEnforcerGetPolicy(t *testing.T, e *SyncedEnforcer, res [][]string) {
 	t.Helper()
-	myRes := e.GetPolicy()
+	myRes, err := e.GetPolicy()
+	if err != nil {
+		t.Error(err)
+	}
 
 	if !util.SortedArray2DEquals(res, myRes) {
 		t.Error("Policy: ", myRes, ", supposed to be ", res)

--- a/frontend.go
+++ b/frontend.go
@@ -27,7 +27,10 @@ func CasbinJsGetPermissionForUser(e IEnforcer, user string) (string, error) {
 
 	pRules := [][]string{}
 	for ptype := range model["p"] {
-		policies := model.GetPolicy("p", ptype)
+		policies, err := model.GetPolicy("p", ptype)
+		if err != nil {
+			return "", err
+		}
 		for _, rules := range policies {
 			pRules = append(pRules, append([]string{ptype}, rules...))
 		}
@@ -36,7 +39,10 @@ func CasbinJsGetPermissionForUser(e IEnforcer, user string) (string, error) {
 
 	gRules := [][]string{}
 	for ptype := range model["g"] {
-		policies := model.GetPolicy("g", ptype)
+		policies, err := model.GetPolicy("g", ptype)
+		if err != nil {
+			return "", err
+		}
 		for _, rules := range policies {
 			gRules = append(gRules, append([]string{ptype}, rules...))
 		}

--- a/internal_api.go
+++ b/internal_api.go
@@ -274,10 +274,12 @@ func (e *Enforcer) updateFilteredPoliciesWithoutNotify(sec string, ptype string,
 				return nil, err
 			}
 		}
-		// For compatibility, because some adapters return oldRules containing ptype, see https://github.com/casbin/xorm-adapter/issues/49
-		for i, oldRule := range oldRules {
-			if len(oldRules[i]) == len(e.model[sec][ptype].Tokens)+1 {
-				oldRules[i] = oldRule[1:]
+		if e.model[sec] != nil && e.model[sec][ptype] != nil {
+			// For compatibility, because some adapters return oldRules containing ptype, see https://github.com/casbin/xorm-adapter/issues/49
+			for i, oldRule := range oldRules {
+				if len(oldRules[i]) == len(e.model[sec][ptype].Tokens)+1 {
+					oldRules[i] = oldRule[1:]
+				}
 			}
 		}
 	}

--- a/internal_api.go
+++ b/internal_api.go
@@ -40,8 +40,9 @@ func (e *Enforcer) addPolicyWithoutNotify(sec string, ptype string, rule []strin
 		return true, e.dispatcher.AddPolicies(sec, ptype, [][]string{rule})
 	}
 
-	if e.model.HasPolicy(sec, ptype, rule) {
-		return false, nil
+	hasPolicy, err := e.model.HasPolicy(sec, ptype, rule)
+	if !hasPolicy || err != nil {
+		return hasPolicy, err
 	}
 
 	if e.shouldPersist() {
@@ -52,7 +53,10 @@ func (e *Enforcer) addPolicyWithoutNotify(sec string, ptype string, rule []strin
 		}
 	}
 
-	e.model.AddPolicy(sec, ptype, rule)
+	err = e.model.AddPolicy(sec, ptype, rule)
+	if err != nil {
+		return false, err
+	}
 
 	if sec == "g" {
 		err := e.BuildIncrementalRoleLinks(model.PolicyAdd, ptype, [][]string{rule})
@@ -72,8 +76,11 @@ func (e *Enforcer) addPoliciesWithoutNotify(sec string, ptype string, rules [][]
 		return true, e.dispatcher.AddPolicies(sec, ptype, rules)
 	}
 
-	if !autoRemoveRepeat && e.model.HasPolicies(sec, ptype, rules) {
-		return false, nil
+	if !autoRemoveRepeat {
+		hasPolicies, err := e.model.HasPolicies(sec, ptype, rules)
+		if !hasPolicies || err != nil {
+			return false, nil
+		}
 	}
 
 	if e.shouldPersist() {
@@ -84,7 +91,10 @@ func (e *Enforcer) addPoliciesWithoutNotify(sec string, ptype string, rules [][]
 		}
 	}
 
-	e.model.AddPolicies(sec, ptype, rules)
+	err := e.model.AddPolicies(sec, ptype, rules)
+	if err != nil {
+		return false, err
+	}
 
 	if sec == "g" {
 		err := e.BuildIncrementalRoleLinks(model.PolicyAdd, ptype, rules)
@@ -115,9 +125,9 @@ func (e *Enforcer) removePolicyWithoutNotify(sec string, ptype string, rule []st
 		}
 	}
 
-	ruleRemoved := e.model.RemovePolicy(sec, ptype, rule)
-	if !ruleRemoved {
-		return ruleRemoved, nil
+	ruleRemoved, err := e.model.RemovePolicy(sec, ptype, rule)
+	if !ruleRemoved || err != nil {
+		return ruleRemoved, err
 	}
 
 	if sec == "g" {
@@ -142,9 +152,9 @@ func (e *Enforcer) updatePolicyWithoutNotify(sec string, ptype string, oldRule [
 			}
 		}
 	}
-	ruleUpdated := e.model.UpdatePolicy(sec, ptype, oldRule, newRule)
-	if !ruleUpdated {
-		return ruleUpdated, nil
+	ruleUpdated, err := e.model.UpdatePolicy(sec, ptype, oldRule, newRule)
+	if !ruleUpdated || err != nil {
+		return ruleUpdated, err
 	}
 
 	if sec == "g" {
@@ -178,9 +188,9 @@ func (e *Enforcer) updatePoliciesWithoutNotify(sec string, ptype string, oldRule
 		}
 	}
 
-	ruleUpdated := e.model.UpdatePolicies(sec, ptype, oldRules, newRules)
-	if !ruleUpdated {
-		return ruleUpdated, nil
+	ruleUpdated, err := e.model.UpdatePolicies(sec, ptype, oldRules, newRules)
+	if !ruleUpdated || err != nil {
+		return ruleUpdated, err
 	}
 
 	if sec == "g" {
@@ -199,8 +209,8 @@ func (e *Enforcer) updatePoliciesWithoutNotify(sec string, ptype string, oldRule
 
 // removePolicies removes rules from the current policy.
 func (e *Enforcer) removePoliciesWithoutNotify(sec string, ptype string, rules [][]string) (bool, error) {
-	if !e.model.HasPolicies(sec, ptype, rules) {
-		return false, nil
+	if hasPolicies, err := e.model.HasPolicies(sec, ptype, rules); !hasPolicies || err != nil {
+		return hasPolicies, err
 	}
 
 	if e.dispatcher != nil && e.autoNotifyDispatcher {
@@ -215,9 +225,9 @@ func (e *Enforcer) removePoliciesWithoutNotify(sec string, ptype string, rules [
 		}
 	}
 
-	rulesRemoved := e.model.RemovePolicies(sec, ptype, rules)
-	if !rulesRemoved {
-		return rulesRemoved, nil
+	rulesRemoved, err := e.model.RemovePolicies(sec, ptype, rules)
+	if !rulesRemoved || err != nil {
+		return rulesRemoved, err
 	}
 
 	if sec == "g" {
@@ -247,9 +257,9 @@ func (e *Enforcer) removeFilteredPolicyWithoutNotify(sec string, ptype string, f
 		}
 	}
 
-	ruleRemoved, effects := e.model.RemoveFilteredPolicy(sec, ptype, fieldIndex, fieldValues...)
-	if !ruleRemoved {
-		return ruleRemoved, nil
+	ruleRemoved, effects, err := e.model.RemoveFilteredPolicy(sec, ptype, fieldIndex, fieldValues...)
+	if !ruleRemoved || err != nil {
+		return ruleRemoved, err
 	}
 
 	if sec == "g" {
@@ -268,8 +278,8 @@ func (e *Enforcer) updateFilteredPoliciesWithoutNotify(sec string, ptype string,
 		err      error
 	)
 
-	if e.model[sec] == nil || e.model[sec][ptype] == nil {
-		return nil, fmt.Errorf("invalid sec: %s, ptype: %s", sec, ptype)
+	if _, err = e.model.GetAssertion(sec, ptype); err != nil {
+		return oldRules, err
 	}
 
 	if e.shouldPersist() {
@@ -290,8 +300,14 @@ func (e *Enforcer) updateFilteredPoliciesWithoutNotify(sec string, ptype string,
 		return oldRules, e.dispatcher.UpdateFilteredPolicies(sec, ptype, oldRules, newRules)
 	}
 
-	ruleChanged := e.model.RemovePolicies(sec, ptype, oldRules)
-	e.model.AddPolicies(sec, ptype, newRules)
+	ruleChanged, err := e.model.RemovePolicies(sec, ptype, oldRules)
+	if err != nil {
+		return oldRules, err
+	}
+	err = e.model.AddPolicies(sec, ptype, newRules)
+	if err != nil {
+		return oldRules, err
+	}
 	ruleChanged = ruleChanged && len(newRules) != 0
 	if !ruleChanged {
 		return make([][]string, 0), nil

--- a/internal_api.go
+++ b/internal_api.go
@@ -268,18 +268,20 @@ func (e *Enforcer) updateFilteredPoliciesWithoutNotify(sec string, ptype string,
 		err      error
 	)
 
+	if e.model[sec] == nil || e.model[sec][ptype] == nil {
+		return nil, fmt.Errorf("invalid sec: %s, ptype: %s", sec, ptype)
+	}
+
 	if e.shouldPersist() {
 		if oldRules, err = e.adapter.(persist.UpdatableAdapter).UpdateFilteredPolicies(sec, ptype, newRules, fieldIndex, fieldValues...); err != nil {
 			if err.Error() != notImplemented {
 				return nil, err
 			}
 		}
-		if e.model[sec] != nil && e.model[sec][ptype] != nil {
-			// For compatibility, because some adapters return oldRules containing ptype, see https://github.com/casbin/xorm-adapter/issues/49
-			for i, oldRule := range oldRules {
-				if len(oldRules[i]) == len(e.model[sec][ptype].Tokens)+1 {
-					oldRules[i] = oldRule[1:]
-				}
+		// For compatibility, because some adapters return oldRules containing ptype, see https://github.com/casbin/xorm-adapter/issues/49
+		for i, oldRule := range oldRules {
+			if len(oldRules[i]) == len(e.model[sec][ptype].Tokens)+1 {
+				oldRules[i] = oldRule[1:]
 			}
 		}
 	}

--- a/internal_api.go
+++ b/internal_api.go
@@ -41,7 +41,7 @@ func (e *Enforcer) addPolicyWithoutNotify(sec string, ptype string, rule []strin
 	}
 
 	hasPolicy, err := e.model.HasPolicy(sec, ptype, rule)
-	if !hasPolicy || err != nil {
+	if hasPolicy || err != nil {
 		return hasPolicy, err
 	}
 
@@ -78,7 +78,7 @@ func (e *Enforcer) addPoliciesWithoutNotify(sec string, ptype string, rules [][]
 
 	if !autoRemoveRepeat {
 		hasPolicies, err := e.model.HasPolicies(sec, ptype, rules)
-		if !hasPolicies || err != nil {
+		if hasPolicies || err != nil {
 			return false, err
 		}
 	}

--- a/internal_api.go
+++ b/internal_api.go
@@ -46,7 +46,7 @@ func (e *Enforcer) addPolicyWithoutNotify(sec string, ptype string, rule []strin
 	}
 
 	if e.shouldPersist() {
-		if err := e.adapter.AddPolicy(sec, ptype, rule); err != nil {
+		if err = e.adapter.AddPolicy(sec, ptype, rule); err != nil {
 			if err.Error() != notImplemented {
 				return false, err
 			}
@@ -79,7 +79,7 @@ func (e *Enforcer) addPoliciesWithoutNotify(sec string, ptype string, rules [][]
 	if !autoRemoveRepeat {
 		hasPolicies, err := e.model.HasPolicies(sec, ptype, rules)
 		if !hasPolicies || err != nil {
-			return false, nil
+			return false, err
 		}
 	}
 

--- a/management_api.go
+++ b/management_api.go
@@ -24,82 +24,82 @@ import (
 )
 
 // GetAllSubjects gets the list of subjects that show up in the current policy.
-func (e *Enforcer) GetAllSubjects() []string {
+func (e *Enforcer) GetAllSubjects() ([]string, error) {
 	return e.model.GetValuesForFieldInPolicyAllTypes("p", 0)
 }
 
 // GetAllNamedSubjects gets the list of subjects that show up in the current named policy.
-func (e *Enforcer) GetAllNamedSubjects(ptype string) []string {
+func (e *Enforcer) GetAllNamedSubjects(ptype string) ([]string, error) {
 	return e.model.GetValuesForFieldInPolicy("p", ptype, 0)
 }
 
 // GetAllObjects gets the list of objects that show up in the current policy.
-func (e *Enforcer) GetAllObjects() []string {
+func (e *Enforcer) GetAllObjects() ([]string, error) {
 	return e.model.GetValuesForFieldInPolicyAllTypes("p", 1)
 }
 
 // GetAllNamedObjects gets the list of objects that show up in the current named policy.
-func (e *Enforcer) GetAllNamedObjects(ptype string) []string {
+func (e *Enforcer) GetAllNamedObjects(ptype string) ([]string, error) {
 	return e.model.GetValuesForFieldInPolicy("p", ptype, 1)
 }
 
 // GetAllActions gets the list of actions that show up in the current policy.
-func (e *Enforcer) GetAllActions() []string {
+func (e *Enforcer) GetAllActions() ([]string, error) {
 	return e.model.GetValuesForFieldInPolicyAllTypes("p", 2)
 }
 
 // GetAllNamedActions gets the list of actions that show up in the current named policy.
-func (e *Enforcer) GetAllNamedActions(ptype string) []string {
+func (e *Enforcer) GetAllNamedActions(ptype string) ([]string, error) {
 	return e.model.GetValuesForFieldInPolicy("p", ptype, 2)
 }
 
 // GetAllRoles gets the list of roles that show up in the current policy.
-func (e *Enforcer) GetAllRoles() []string {
+func (e *Enforcer) GetAllRoles() ([]string, error) {
 	return e.model.GetValuesForFieldInPolicyAllTypes("g", 1)
 }
 
 // GetAllNamedRoles gets the list of roles that show up in the current named policy.
-func (e *Enforcer) GetAllNamedRoles(ptype string) []string {
+func (e *Enforcer) GetAllNamedRoles(ptype string) ([]string, error) {
 	return e.model.GetValuesForFieldInPolicy("g", ptype, 1)
 }
 
 // GetPolicy gets all the authorization rules in the policy.
-func (e *Enforcer) GetPolicy() [][]string {
+func (e *Enforcer) GetPolicy() ([][]string, error) {
 	return e.GetNamedPolicy("p")
 }
 
 // GetFilteredPolicy gets all the authorization rules in the policy, field filters can be specified.
-func (e *Enforcer) GetFilteredPolicy(fieldIndex int, fieldValues ...string) [][]string {
+func (e *Enforcer) GetFilteredPolicy(fieldIndex int, fieldValues ...string) ([][]string, error) {
 	return e.GetFilteredNamedPolicy("p", fieldIndex, fieldValues...)
 }
 
 // GetNamedPolicy gets all the authorization rules in the named policy.
-func (e *Enforcer) GetNamedPolicy(ptype string) [][]string {
+func (e *Enforcer) GetNamedPolicy(ptype string) ([][]string, error) {
 	return e.model.GetPolicy("p", ptype)
 }
 
 // GetFilteredNamedPolicy gets all the authorization rules in the named policy, field filters can be specified.
-func (e *Enforcer) GetFilteredNamedPolicy(ptype string, fieldIndex int, fieldValues ...string) [][]string {
+func (e *Enforcer) GetFilteredNamedPolicy(ptype string, fieldIndex int, fieldValues ...string) ([][]string, error) {
 	return e.model.GetFilteredPolicy("p", ptype, fieldIndex, fieldValues...)
 }
 
 // GetGroupingPolicy gets all the role inheritance rules in the policy.
-func (e *Enforcer) GetGroupingPolicy() [][]string {
+func (e *Enforcer) GetGroupingPolicy() ([][]string, error) {
 	return e.GetNamedGroupingPolicy("g")
 }
 
 // GetFilteredGroupingPolicy gets all the role inheritance rules in the policy, field filters can be specified.
-func (e *Enforcer) GetFilteredGroupingPolicy(fieldIndex int, fieldValues ...string) [][]string {
+func (e *Enforcer) GetFilteredGroupingPolicy(fieldIndex int, fieldValues ...string) ([][]string, error) {
 	return e.GetFilteredNamedGroupingPolicy("g", fieldIndex, fieldValues...)
 }
 
 // GetNamedGroupingPolicy gets all the role inheritance rules in the policy.
-func (e *Enforcer) GetNamedGroupingPolicy(ptype string) [][]string {
+func (e *Enforcer) GetNamedGroupingPolicy(ptype string) ([][]string, error) {
 	return e.model.GetPolicy("g", ptype)
 }
 
 // GetFilteredNamedGroupingPolicy gets all the role inheritance rules in the policy, field filters can be specified.
-func (e *Enforcer) GetFilteredNamedGroupingPolicy(ptype string, fieldIndex int, fieldValues ...string) [][]string {
+func (e *Enforcer) GetFilteredNamedGroupingPolicy(ptype string, fieldIndex int, fieldValues ...string) ([][]string, error) {
 	return e.model.GetFilteredPolicy("g", ptype, fieldIndex, fieldValues...)
 }
 
@@ -182,12 +182,12 @@ func (e *Enforcer) GetFilteredNamedPolicyWithMatcher(ptype string, matcher strin
 }
 
 // HasPolicy determines whether an authorization rule exists.
-func (e *Enforcer) HasPolicy(params ...interface{}) bool {
+func (e *Enforcer) HasPolicy(params ...interface{}) (bool, error) {
 	return e.HasNamedPolicy("p", params...)
 }
 
 // HasNamedPolicy determines whether a named authorization rule exists.
-func (e *Enforcer) HasNamedPolicy(ptype string, params ...interface{}) bool {
+func (e *Enforcer) HasNamedPolicy(ptype string, params ...interface{}) (bool, error) {
 	if strSlice, ok := params[0].([]string); len(params) == 1 && ok {
 		return e.model.HasPolicy("p", ptype, strSlice)
 	}
@@ -316,12 +316,12 @@ func (e *Enforcer) RemoveFilteredNamedPolicy(ptype string, fieldIndex int, field
 }
 
 // HasGroupingPolicy determines whether a role inheritance rule exists.
-func (e *Enforcer) HasGroupingPolicy(params ...interface{}) bool {
+func (e *Enforcer) HasGroupingPolicy(params ...interface{}) (bool, error) {
 	return e.HasNamedGroupingPolicy("g", params...)
 }
 
 // HasNamedGroupingPolicy determines whether a named role inheritance rule exists.
-func (e *Enforcer) HasNamedGroupingPolicy(ptype string, params ...interface{}) bool {
+func (e *Enforcer) HasNamedGroupingPolicy(ptype string, params ...interface{}) (bool, error) {
 	if strSlice, ok := params[0].([]string); len(params) == 1 && ok {
 		return e.model.HasPolicy("g", ptype, strSlice)
 	}

--- a/management_api_test.go
+++ b/management_api_test.go
@@ -20,9 +20,12 @@ import (
 	"github.com/casbin/casbin/v2/util"
 )
 
-func testStringList(t *testing.T, title string, f func() []string, res []string) {
+func testStringList(t *testing.T, title string, f func() ([]string, error), res []string) {
 	t.Helper()
-	myRes := f()
+	myRes, err := f()
+	if err != nil {
+		t.Error(err)
+	}
 	t.Log(title+": ", myRes)
 
 	if !util.ArrayEquals(res, myRes) {
@@ -41,7 +44,10 @@ func TestGetList(t *testing.T) {
 
 func testGetPolicy(t *testing.T, e *Enforcer, res [][]string) {
 	t.Helper()
-	myRes := e.GetPolicy()
+	myRes, err := e.GetPolicy()
+	if err != nil {
+		t.Error(err)
+	}
 	t.Log("Policy: ", myRes)
 
 	if !util.Array2DEquals(res, myRes) {
@@ -51,7 +57,10 @@ func testGetPolicy(t *testing.T, e *Enforcer, res [][]string) {
 
 func testGetFilteredPolicy(t *testing.T, e *Enforcer, fieldIndex int, res [][]string, fieldValues ...string) {
 	t.Helper()
-	myRes := e.GetFilteredPolicy(fieldIndex, fieldValues...)
+	myRes, err := e.GetFilteredPolicy(fieldIndex, fieldValues...)
+	if err != nil {
+		t.Error(err)
+	}
 	t.Log("Policy for ", util.ParamsToString(fieldValues...), ": ", myRes)
 
 	if !util.Array2DEquals(res, myRes) {
@@ -75,7 +84,10 @@ func testGetFilteredNamedPolicyWithMatcher(t *testing.T, e *Enforcer, ptype stri
 
 func testGetGroupingPolicy(t *testing.T, e *Enforcer, res [][]string) {
 	t.Helper()
-	myRes := e.GetGroupingPolicy()
+	myRes, err := e.GetGroupingPolicy()
+	if err != nil {
+		t.Error(err)
+	}
 	t.Log("Grouping policy: ", myRes)
 
 	if !util.Array2DEquals(res, myRes) {
@@ -85,7 +97,10 @@ func testGetGroupingPolicy(t *testing.T, e *Enforcer, res [][]string) {
 
 func testGetFilteredGroupingPolicy(t *testing.T, e *Enforcer, fieldIndex int, res [][]string, fieldValues ...string) {
 	t.Helper()
-	myRes := e.GetFilteredGroupingPolicy(fieldIndex, fieldValues...)
+	myRes, err := e.GetFilteredGroupingPolicy(fieldIndex, fieldValues...)
+	if err != nil {
+		t.Error(err)
+	}
 	t.Log("Grouping policy for ", util.ParamsToString(fieldValues...), ": ", myRes)
 
 	if !util.Array2DEquals(res, myRes) {
@@ -95,7 +110,10 @@ func testGetFilteredGroupingPolicy(t *testing.T, e *Enforcer, fieldIndex int, re
 
 func testHasPolicy(t *testing.T, e *Enforcer, policy []string, res bool) {
 	t.Helper()
-	myRes := e.HasPolicy(policy)
+	myRes, err := e.HasPolicy(policy)
+	if err != nil {
+		t.Error(err)
+	}
 	t.Log("Has policy ", util.ArrayToString(policy), ": ", myRes)
 
 	if res != myRes {
@@ -105,7 +123,10 @@ func testHasPolicy(t *testing.T, e *Enforcer, policy []string, res bool) {
 
 func testHasGroupingPolicy(t *testing.T, e *Enforcer, policy []string, res bool) {
 	t.Helper()
-	myRes := e.HasGroupingPolicy(policy)
+	myRes, err := e.HasGroupingPolicy(policy)
+	if err != nil {
+		t.Error(err)
+	}
 	t.Log("Has grouping policy ", util.ArrayToString(policy), ": ", myRes)
 
 	if res != myRes {

--- a/management_api_test.go
+++ b/management_api_test.go
@@ -26,6 +26,7 @@ func testStringList(t *testing.T, title string, f func() ([]string, error), res 
 	if err != nil {
 		t.Error(err)
 	}
+
 	t.Log(title+": ", myRes)
 
 	if !util.ArrayEquals(res, myRes) {
@@ -48,6 +49,7 @@ func testGetPolicy(t *testing.T, e *Enforcer, res [][]string) {
 	if err != nil {
 		t.Error(err)
 	}
+
 	t.Log("Policy: ", myRes)
 
 	if !util.Array2DEquals(res, myRes) {
@@ -61,6 +63,7 @@ func testGetFilteredPolicy(t *testing.T, e *Enforcer, fieldIndex int, res [][]st
 	if err != nil {
 		t.Error(err)
 	}
+
 	t.Log("Policy for ", util.ParamsToString(fieldValues...), ": ", myRes)
 
 	if !util.Array2DEquals(res, myRes) {
@@ -88,6 +91,7 @@ func testGetGroupingPolicy(t *testing.T, e *Enforcer, res [][]string) {
 	if err != nil {
 		t.Error(err)
 	}
+
 	t.Log("Grouping policy: ", myRes)
 
 	if !util.Array2DEquals(res, myRes) {
@@ -101,6 +105,7 @@ func testGetFilteredGroupingPolicy(t *testing.T, e *Enforcer, fieldIndex int, re
 	if err != nil {
 		t.Error(err)
 	}
+
 	t.Log("Grouping policy for ", util.ParamsToString(fieldValues...), ": ", myRes)
 
 	if !util.Array2DEquals(res, myRes) {
@@ -114,6 +119,7 @@ func testHasPolicy(t *testing.T, e *Enforcer, policy []string, res bool) {
 	if err != nil {
 		t.Error(err)
 	}
+
 	t.Log("Has policy ", util.ArrayToString(policy), ": ", myRes)
 
 	if res != myRes {
@@ -127,6 +133,7 @@ func testHasGroupingPolicy(t *testing.T, e *Enforcer, policy []string, res bool)
 	if err != nil {
 		t.Error(err)
 	}
+
 	t.Log("Has grouping policy ", util.ArrayToString(policy), ": ", myRes)
 
 	if res != myRes {

--- a/model/model.go
+++ b/model/model.go
@@ -212,6 +212,16 @@ func (model Model) hasSection(sec string) bool {
 	return section != nil
 }
 
+func (model Model) GetAssertion(sec string, ptype string) (*Assertion, error) {
+	if model[sec] == nil {
+		return nil, fmt.Errorf("missing required section %s", sec)
+	}
+	if model[sec][ptype] == nil {
+		return nil, fmt.Errorf("missiong required definition %s in section %s", ptype, sec)
+	}
+	return model[sec][ptype], nil
+}
+
 // PrintModel prints the model to the log.
 func (model Model) PrintModel() {
 	if !model.GetLogger().IsEnabled() {
@@ -236,8 +246,9 @@ func (model Model) SortPoliciesBySubjectHierarchy() error {
 	if model["e"]["e"].Value != constant.SubjectPriorityEffect {
 		return nil
 	}
-	if model["g"] == nil || model["g"]["g"] == nil {
-		return errors.New("role definition is not initialized")
+	g, err := model.GetAssertion("g", "g")
+	if err != nil {
+		return err
 	}
 	subIndex := 0
 	for ptype, assertion := range model["p"] {
@@ -246,7 +257,7 @@ func (model Model) SortPoliciesBySubjectHierarchy() error {
 			domainIndex = -1
 		}
 		policies := assertion.Policy
-		subjectHierarchyMap, err := getSubjectHierarchyMap(model["g"]["g"].Policy)
+		subjectHierarchyMap, err := getSubjectHierarchyMap(g.Policy)
 		if err != nil {
 			return err
 		}

--- a/model/model.go
+++ b/model/model.go
@@ -236,6 +236,9 @@ func (model Model) SortPoliciesBySubjectHierarchy() error {
 	if model["e"]["e"].Value != constant.SubjectPriorityEffect {
 		return nil
 	}
+	if model["g"] == nil || model["g"]["g"] == nil {
+		return errors.New("role definition is not initialized")
+	}
 	subIndex := 0
 	for ptype, assertion := range model["p"] {
 		domainIndex, err := model.GetFieldIndex(ptype, constant.DomainIndex)

--- a/model/policy.go
+++ b/model/policy.go
@@ -137,7 +137,7 @@ func (model Model) ClearPolicy() {
 func (model Model) GetPolicy(sec string, ptype string) ([][]string, error) {
 	_, err := model.GetAssertion(sec, ptype)
 	if err != nil {
-		return [][]string{}, err
+		return nil, err
 	}
 	return model[sec][ptype].Policy, nil
 }
@@ -146,7 +146,7 @@ func (model Model) GetPolicy(sec string, ptype string) ([][]string, error) {
 func (model Model) GetFilteredPolicy(sec string, ptype string, fieldIndex int, fieldValues ...string) ([][]string, error) {
 	_, err := model.GetAssertion(sec, ptype)
 	if err != nil {
-		return [][]string{}, err
+		return nil, err
 	}
 	res := [][]string{}
 
@@ -260,7 +260,7 @@ func (model Model) AddPolicies(sec string, ptype string, rules [][]string) error
 func (model Model) AddPoliciesWithAffected(sec string, ptype string, rules [][]string) ([][]string, error) {
 	_, err := model.GetAssertion(sec, ptype)
 	if err != nil {
-		return [][]string{}, err
+		return nil, err
 	}
 	var affected [][]string
 	for _, rule := range rules {
@@ -272,7 +272,7 @@ func (model Model) AddPoliciesWithAffected(sec string, ptype string, rules [][]s
 		affected = append(affected, rule)
 		err = model.AddPolicy(sec, ptype, rule)
 		if err != nil {
-			break
+			return affected, err
 		}
 	}
 	return affected, err
@@ -392,7 +392,7 @@ func (model Model) RemovePoliciesWithAffected(sec string, ptype string, rules []
 func (model Model) RemoveFilteredPolicy(sec string, ptype string, fieldIndex int, fieldValues ...string) (bool, [][]string, error) {
 	_, err := model.GetAssertion(sec, ptype)
 	if err != nil {
-		return false, [][]string{}, err
+		return false, nil, err
 	}
 	var tmp [][]string
 	var effects [][]string

--- a/model_test.go
+++ b/model_test.go
@@ -338,6 +338,7 @@ func TestRBACModelWithDifferentTypesOfRoles(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
+
 	for _, gp := range g {
 		if len(gp) != 5 {
 			t.Error("g parameters' num isn't 5")

--- a/model_test.go
+++ b/model_test.go
@@ -334,7 +334,10 @@ func TestRBACModelWithPattern(t *testing.T) {
 func TestRBACModelWithDifferentTypesOfRoles(t *testing.T) {
 	e, _ := NewEnforcer("examples/rbac_with_different_types_of_roles_model.conf", "examples/rbac_with_different_types_of_roles_policy.csv")
 
-	g := e.GetNamedGroupingPolicy("g")
+	g, err := e.GetNamedGroupingPolicy("g")
+	if err != nil {
+		t.Error(err)
+	}
 	for _, gp := range g {
 		if len(gp) != 5 {
 			t.Error("g parameters' num isn't 5")

--- a/rbac_api.go
+++ b/rbac_api.go
@@ -199,7 +199,8 @@ func (e *Enforcer) GetNamedPermissionsForUser(ptype string, user string, domain 
 		args[subIndex] = user
 
 		if len(domain) > 0 {
-			index, err := e.GetFieldIndex(ptype, constant.DomainIndex)
+			var index int
+			index, err = e.GetFieldIndex(ptype, constant.DomainIndex)
 			if err != nil {
 				return permission, err
 			}

--- a/rbac_api.go
+++ b/rbac_api.go
@@ -550,8 +550,12 @@ func (e *Enforcer) GetImplicitUsersForResourceByDomain(resource string, domain s
 
 	isRole := make(map[string]bool)
 
-	for _, role := range e.GetAllRolesByDomain(domain) {
-		isRole[role] = true
+	if roles, err := e.GetAllRolesByDomain(domain); err != nil {
+		return nil, err
+	} else {
+		for _, role := range roles {
+			isRole[role] = true
+		}
 	}
 
 	for _, rule := range e.model["p"]["p"].Policy {

--- a/rbac_api.go
+++ b/rbac_api.go
@@ -205,14 +205,17 @@ func (e *Enforcer) GetNamedPermissionsForUser(ptype string, user string, domain 
 			}
 			args[index] = domain[0]
 		}
-		perm := e.GetFilteredNamedPolicy(ptype, 0, args...)
+		perm, err := e.GetFilteredNamedPolicy(ptype, 0, args...)
+		if err != nil {
+			return permission, err
+		}
 		permission = append(permission, perm...)
 	}
 	return permission, nil
 }
 
 // HasPermissionForUser determines whether a user has a permission.
-func (e *Enforcer) HasPermissionForUser(user string, permission ...string) bool {
+func (e *Enforcer) HasPermissionForUser(user string, permission ...string) (bool, error) {
 	return e.HasPolicy(util.JoinSlice(user, permission...))
 }
 
@@ -349,9 +352,18 @@ func (e *Enforcer) GetNamedImplicitPermissionsForUser(ptype string, user string,
 // GetImplicitUsersForPermission("data1", "read") will get: ["alice", "bob"].
 // Note: only users will be returned, roles (2nd arg in "g") will be excluded.
 func (e *Enforcer) GetImplicitUsersForPermission(permission ...string) ([]string, error) {
-	pSubjects := e.GetAllSubjects()
-	gInherit := e.model.GetValuesForFieldInPolicyAllTypes("g", 1)
-	gSubjects := e.model.GetValuesForFieldInPolicyAllTypes("g", 0)
+	pSubjects, err := e.GetAllSubjects()
+	if err != nil {
+		return nil, err
+	}
+	gInherit, err := e.model.GetValuesForFieldInPolicyAllTypes("g", 1)
+	if err != nil {
+		return nil, err
+	}
+	gSubjects, err := e.model.GetValuesForFieldInPolicyAllTypes("g", 0)
+	if err != nil {
+		return nil, err
+	}
 
 	subjects := append(pSubjects, gSubjects...)
 	util.ArrayRemoveDuplicates(&subjects)
@@ -504,7 +516,11 @@ func (e *Enforcer) GetImplicitUsersForResource(resource string) ([][]string, err
 	}
 
 	isRole := make(map[string]bool)
-	for _, role := range e.GetAllRoles() {
+	roles, err := e.GetAllRoles()
+	if err != nil {
+		return nil, err
+	}
+	for _, role := range roles {
 		isRole[role] = true
 	}
 

--- a/rbac_api_synced.go
+++ b/rbac_api_synced.go
@@ -138,7 +138,7 @@ func (e *SyncedEnforcer) GetNamedPermissionsForUser(ptype string, user string, d
 }
 
 // HasPermissionForUser determines whether a user has a permission.
-func (e *SyncedEnforcer) HasPermissionForUser(user string, permission ...string) bool {
+func (e *SyncedEnforcer) HasPermissionForUser(user string, permission ...string) (bool, error) {
 	e.m.RLock()
 	defer e.m.RUnlock()
 	return e.Enforcer.HasPermissionForUser(user, permission...)

--- a/rbac_api_test.go
+++ b/rbac_api_test.go
@@ -208,6 +208,7 @@ func testHasPermission(t *testing.T, e *Enforcer, name string, permission []stri
 	if err != nil {
 		t.Error(err.Error())
 	}
+
 	t.Log(name, " has permission ", util.ArrayToString(permission), ": ", myRes)
 
 	if res != myRes {

--- a/rbac_api_test.go
+++ b/rbac_api_test.go
@@ -204,7 +204,10 @@ func testGetPermissions(t *testing.T, e *Enforcer, name string, res [][]string, 
 
 func testHasPermission(t *testing.T, e *Enforcer, name string, permission []string, res bool) {
 	t.Helper()
-	myRes := e.HasPermissionForUser(name, permission...)
+	myRes, err := e.HasPermissionForUser(name, permission...)
+	if err != nil {
+		t.Error(err.Error())
+	}
 	t.Log(name, " has permission ", util.ArrayToString(permission), ": ", myRes)
 
 	if res != myRes {

--- a/rbac_api_with_domains.go
+++ b/rbac_api_with_domains.go
@@ -77,11 +77,11 @@ func (e *Enforcer) DeleteRolesForUserInDomain(user string, domain string) (bool,
 
 // GetAllUsersByDomain would get all users associated with the domain.
 func (e *Enforcer) GetAllUsersByDomain(domain string) ([]string, error) {
-	if e.model["g"] == nil || e.model["g"]["g"] == nil {
-		return []string{}, fmt.Errorf("role definition is not initialized")
-	}
 	m := make(map[string]struct{})
-	g := e.model["g"]["g"]
+	g, err := e.model.GetAssertion("g", "g")
+	if err != nil {
+		return []string{}, err
+	}
 	p := e.model["p"]["p"]
 	users := make([]string, 0)
 	index, err := e.GetFieldIndex("p", constant.DomainIndex)
@@ -110,10 +110,10 @@ func (e *Enforcer) GetAllUsersByDomain(domain string) ([]string, error) {
 
 // DeleteAllUsersByDomain would delete all users associated with the domain.
 func (e *Enforcer) DeleteAllUsersByDomain(domain string) (bool, error) {
-	if e.model["g"] == nil || e.model["g"]["g"] == nil {
-		return false, fmt.Errorf("role definition is not initialized")
+	g, err := e.model.GetAssertion("g", "g")
+	if err != nil {
+		return false, err
 	}
-	g := e.model["g"]["g"]
 	p := e.model["p"]["p"]
 	index, err := e.GetFieldIndex("p", constant.DomainIndex)
 	if err != nil {
@@ -134,11 +134,11 @@ func (e *Enforcer) DeleteAllUsersByDomain(domain string) (bool, error) {
 	}
 
 	users := getUser(2, g.Policy, domain)
-	if _, err := e.RemoveGroupingPolicies(users); err != nil {
+	if _, err = e.RemoveGroupingPolicies(users); err != nil {
 		return false, err
 	}
 	users = getUser(index, p.Policy, domain)
-	if _, err := e.RemovePolicies(users); err != nil {
+	if _, err = e.RemovePolicies(users); err != nil {
 		return false, err
 	}
 	return true, nil
@@ -170,10 +170,10 @@ func (e *Enforcer) GetAllDomains() ([]string, error) {
 // GetAllRolesByDomain would get all roles associated with the domain.
 // note: Not applicable to Domains with inheritance relationship  (implicit roles)
 func (e *Enforcer) GetAllRolesByDomain(domain string) ([]string, error) {
-	if e.model["g"] == nil || e.model["g"]["g"] == nil {
-		return []string{}, fmt.Errorf("role definition is not initialized")
+	g, err := e.model.GetAssertion("g", "g")
+	if err != nil {
+		return []string{}, err
 	}
-	g := e.model["g"]["g"]
 	policies := g.Policy
 	roles := make([]string, 0)
 	existMap := make(map[string]bool) // remove duplicates

--- a/rbac_api_with_domains.go
+++ b/rbac_api_with_domains.go
@@ -76,14 +76,17 @@ func (e *Enforcer) DeleteRolesForUserInDomain(user string, domain string) (bool,
 }
 
 // GetAllUsersByDomain would get all users associated with the domain.
-func (e *Enforcer) GetAllUsersByDomain(domain string) []string {
+func (e *Enforcer) GetAllUsersByDomain(domain string) ([]string, error) {
+	if e.model["g"] == nil || e.model["g"]["g"] == nil {
+		return []string{}, fmt.Errorf("role definition is not initialized")
+	}
 	m := make(map[string]struct{})
 	g := e.model["g"]["g"]
 	p := e.model["p"]["p"]
 	users := make([]string, 0)
 	index, err := e.GetFieldIndex("p", constant.DomainIndex)
 	if err != nil {
-		return []string{}
+		return []string{}, err
 	}
 
 	getUser := func(index int, policies [][]string, domain string, m map[string]struct{}) []string {
@@ -102,11 +105,14 @@ func (e *Enforcer) GetAllUsersByDomain(domain string) []string {
 
 	users = append(users, getUser(2, g.Policy, domain, m)...)
 	users = append(users, getUser(index, p.Policy, domain, m)...)
-	return users
+	return users, nil
 }
 
 // DeleteAllUsersByDomain would delete all users associated with the domain.
 func (e *Enforcer) DeleteAllUsersByDomain(domain string) (bool, error) {
+	if e.model["g"] == nil || e.model["g"]["g"] == nil {
+		return false, fmt.Errorf("role definition is not initialized")
+	}
 	g := e.model["g"]["g"]
 	p := e.model["p"]["p"]
 	index, err := e.GetFieldIndex("p", constant.DomainIndex)
@@ -163,7 +169,10 @@ func (e *Enforcer) GetAllDomains() ([]string, error) {
 
 // GetAllRolesByDomain would get all roles associated with the domain.
 // note: Not applicable to Domains with inheritance relationship  (implicit roles)
-func (e *Enforcer) GetAllRolesByDomain(domain string) []string {
+func (e *Enforcer) GetAllRolesByDomain(domain string) ([]string, error) {
+	if e.model["g"] == nil || e.model["g"]["g"] == nil {
+		return []string{}, fmt.Errorf("role definition is not initialized")
+	}
 	g := e.model["g"]["g"]
 	policies := g.Policy
 	roles := make([]string, 0)
@@ -179,5 +188,5 @@ func (e *Enforcer) GetAllRolesByDomain(domain string) []string {
 		}
 	}
 
-	return roles
+	return roles, nil
 }

--- a/rbac_api_with_domains_test.go
+++ b/rbac_api_with_domains_test.go
@@ -228,11 +228,19 @@ func testDeleteAllUsersByDomain(t *testing.T, domain string, expectedPolicy, exp
 	e, _ := NewEnforcer("examples/rbac_with_domains_model.conf", "examples/rbac_with_domains_policy.csv")
 
 	_, _ = e.DeleteAllUsersByDomain(domain)
-	if !util.Array2DEquals(e.GetPolicy(), expectedPolicy) {
-		t.Errorf("policy in %s: %v, supposed to be %v\n", domain, e.GetPolicy(), expectedPolicy)
+	policy, err := e.GetPolicy()
+	if err != nil {
+		t.Error(err)
 	}
-	if !util.Array2DEquals(e.GetGroupingPolicy(), expectedGroupingPolicy) {
-		t.Errorf("grouping policy in %s: %v, supposed to be %v\n", domain, e.GetGroupingPolicy(), expectedGroupingPolicy)
+	if !util.Array2DEquals(policy, expectedPolicy) {
+		t.Errorf("policy in %s: %v, supposed to be %v\n", domain, policy, expectedPolicy)
+	}
+	policies, err := e.GetGroupingPolicy()
+	if err != nil {
+		t.Error(err)
+	}
+	if !util.Array2DEquals(policies, expectedGroupingPolicy) {
+		t.Errorf("grouping policy in %s: %v, supposed to be %v\n", domain, policies, expectedGroupingPolicy)
 	}
 }
 

--- a/rbac_api_with_domains_test.go
+++ b/rbac_api_with_domains_test.go
@@ -235,6 +235,7 @@ func testDeleteAllUsersByDomain(t *testing.T, domain string, expectedPolicy, exp
 	if !util.Array2DEquals(policy, expectedPolicy) {
 		t.Errorf("policy in %s: %v, supposed to be %v\n", domain, policy, expectedPolicy)
 	}
+
 	policies, err := e.GetGroupingPolicy()
 	if err != nil {
 		t.Error(err)

--- a/rbac_api_with_domains_test.go
+++ b/rbac_api_with_domains_test.go
@@ -211,8 +211,9 @@ func TestGetDomainsForUser(t *testing.T) {
 }
 
 func testGetAllUsersByDomain(t *testing.T, e *Enforcer, domain string, expected []string) {
-	if !util.SetEquals(e.GetAllUsersByDomain(domain), expected) {
-		t.Errorf("users in %s: %v, supposed to be %v\n", domain, e.GetAllUsersByDomain(domain), expected)
+	users, _ := e.GetAllUsersByDomain(domain)
+	if !util.SetEquals(users, expected) {
+		t.Errorf("users in %s: %v, supposed to be %v\n", domain, users, expected)
 	}
 }
 
@@ -268,8 +269,9 @@ func TestGetAllDomains(t *testing.T) {
 }
 
 func testGetAllRolesByDomain(t *testing.T, e *Enforcer, domain string, expected []string) {
-	if !util.SetEquals(e.GetAllRolesByDomain(domain), expected) {
-		t.Errorf("roles in %s: %v, supposed to be %v\n", domain, e.GetAllRolesByDomain(domain), expected)
+	roles, _ := e.GetAllRolesByDomain(domain)
+	if !util.SetEquals(roles, expected) {
+		t.Errorf("roles in %s: %v, supposed to be %v\n", domain, roles, expected)
 	}
 }
 


### PR DESCRIPTION
Fix #1369 

This issue was paritially fixed by #1371, and this PR contains a fully fix.

- Add nil check on `model` before anywhere `model["g"]["g"]` may be accessed.
- **Public API changed**