### PR TITLE
feat: add ContextFilteredAdapter, ContextBatchAdapter, ContextUpdatableAdapter interfaces

### DIFF
--- a/persist/adapter_filtered_context.go
+++ b/persist/adapter_filtered_context.go
@@ -1,3 +1,17 @@
+// Copyright 2024 The casbin Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package persist
 
 import (
@@ -6,8 +20,8 @@ import (
 	"github.com/casbin/casbin/v2/model"
 )
 
-// FilteredContextAdapter is the context-aware interface for Casbin adapters supporting filtered policies.
-type FilteredContextAdapter interface {
+// ContextFilteredAdapter is the context-aware interface for Casbin adapters supporting filtered policies.
+type ContextFilteredAdapter interface {
 	ContextAdapter
 
 	// LoadFilteredPolicyCtx loads only policy rules that match the filter.

--- a/persist/adapter_filtered_context.go
+++ b/persist/adapter_filtered_context.go
@@ -1,0 +1,17 @@
+package persist
+
+import (
+	"context"
+
+	"github.com/casbin/casbin/v2/model"
+)
+
+// FilteredContextAdapter is the context-aware interface for Casbin adapters supporting filtered policies.
+type FilteredContextAdapter interface {
+	ContextAdapter
+
+	// LoadFilteredPolicyCtx loads only policy rules that match the filter.
+	LoadFilteredPolicyCtx(ctx context.Context, model model.Model, filter interface{}) error
+	// IsFilteredCtx returns true if the loaded policy has been filtered.
+	IsFilteredCtx(ctx context.Context) bool
+}

--- a/persist/batch_adapter_context.go
+++ b/persist/batch_adapter_context.go
@@ -1,10 +1,25 @@
+// Copyright 2024 The casbin Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package persist
 
 import "context"
 
-// BatchContextAdapter is the context-aware interface for Casbin adapters with multiple add and remove policy functions.
-type BatchContextAdapter interface {
+// ContextBatchAdapter is the context-aware interface for Casbin adapters with multiple add and remove policy functions.
+type ContextBatchAdapter interface {
 	ContextAdapter
+
 	// AddPoliciesCtx adds policy rules to the storage.
 	// This is part of the Auto-Save feature.
 	AddPoliciesCtx(ctx context.Context, sec string, ptype string, rules [][]string) error

--- a/persist/batch_adapter_context.go
+++ b/persist/batch_adapter_context.go
@@ -1,0 +1,14 @@
+package persist
+
+import "context"
+
+// BatchContextAdapter is the context-aware interface for Casbin adapters with multiple add and remove policy functions.
+type BatchContextAdapter interface {
+	ContextAdapter
+	// AddPoliciesCtx adds policy rules to the storage.
+	// This is part of the Auto-Save feature.
+	AddPoliciesCtx(ctx context.Context, sec string, ptype string, rules [][]string) error
+	// RemovePoliciesCtx removes policy rules from the storage.
+	// This is part of the Auto-Save feature.
+	RemovePoliciesCtx(ctx context.Context, sec string, ptype string, rules [][]string) error
+}

--- a/persist/update_adapter_context.go
+++ b/persist/update_adapter_context.go
@@ -1,10 +1,25 @@
+// Copyright 2024 The casbin Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package persist
 
 import "context"
 
-// UpdatableContextAdapter is the context-aware interface for Casbin adapters with add update policy function.
-type UpdatableContextAdapter interface {
+// ContextUpdatableAdapter is the context-aware interface for Casbin adapters with add update policy function.
+type ContextUpdatableAdapter interface {
 	ContextAdapter
+
 	// UpdatePolicyCtx updates a policy rule from storage.
 	// This is part of the Auto-Save feature.
 	UpdatePolicyCtx(ctx context.Context, sec string, ptype string, oldRule, newRule []string) error

--- a/persist/update_adapter_context.go
+++ b/persist/update_adapter_context.go
@@ -1,0 +1,15 @@
+package persist
+
+import "context"
+
+// UpdatableContextAdapter is the context-aware interface for Casbin adapters with add update policy function.
+type UpdatableContextAdapter interface {
+	ContextAdapter
+	// UpdatePolicyCtx updates a policy rule from storage.
+	// This is part of the Auto-Save feature.
+	UpdatePolicyCtx(ctx context.Context, sec string, ptype string, oldRule, newRule []string) error
+	// UpdatePoliciesCtx updates some policy rules to storage, like db, redis.
+	UpdatePoliciesCtx(ctx context.Context, sec string, ptype string, oldRules, newRules [][]string) error
+	// UpdateFilteredPoliciesCtx deletes old rules and adds new rules.
+	UpdateFilteredPoliciesCtx(ctx context.Context, sec string, ptype string, newRules [][]string, fieldIndex int, fieldValues ...string) ([][]string, error)
+}


### PR DESCRIPTION
By adding `filtered`, `batch`, `update` interfaces, make the `ContextAdapter` have equivalent definitions to `Adapter`

Fix #1397 