### PR TITLE
feat: refactor `LoadPolicy`, delete `LoadPolicyFast`

### DIFF
--- a/enforcer.go
+++ b/enforcer.go
@@ -354,7 +354,19 @@ func (e *Enforcer) loadPolicyFromAdapter(baseModel model.Model) (model.Model, er
 }
 
 func (e *Enforcer) applyModifiedModel(newModel model.Model) error {
+	var err error
+	needToRebuild := false
+	defer func() {
+		if err != nil {
+			if e.autoBuildRoleLinks && needToRebuild {
+				_ = e.BuildRoleLinks()
+			}
+		}
+	}()
+
 	if e.autoBuildRoleLinks {
+		needToRebuild = true
+
 		if err := e.rebuildRoleLinks(newModel); err != nil {
 			return err
 		}
@@ -362,8 +374,6 @@ func (e *Enforcer) applyModifiedModel(newModel model.Model) error {
 		if err := e.rebuildConditionalRoleLinks(newModel); err != nil {
 			return err
 		}
-
-		_ = e.BuildRoleLinks()
 	}
 
 	e.model = newModel


### PR DESCRIPTION
- `LoadPolicyFast` was added in #1109
- `LoadPolicyFast` has duplicate logic with `LoadPolicy` and is outdated caused by logic changes in `LoadPolicy`
- This PR delete the duplicate logic and reduce the lock range in a different way

Fix #1332 