### PR TITLE
feat: GetAllObjects has wrong result in RBAC with domains model

### DIFF
--- a/constant/constants.go
+++ b/constant/constants.go
@@ -15,6 +15,7 @@
 package constant
 
 const (
+	ActionIndex   = "act"
 	DomainIndex   = "dom"
 	SubjectIndex  = "sub"
 	ObjectIndex   = "obj"

--- a/management_api.go
+++ b/management_api.go
@@ -19,38 +19,51 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/casbin/casbin/v2/constant"
 	"github.com/casbin/casbin/v2/util"
 	"github.com/casbin/govaluate"
 )
 
 // GetAllSubjects gets the list of subjects that show up in the current policy.
 func (e *Enforcer) GetAllSubjects() ([]string, error) {
-	return e.model.GetValuesForFieldInPolicyAllTypes("p", 0)
+	return e.model.GetValuesForFieldInPolicyAllTypesByName("p", constant.SubjectIndex)
 }
 
 // GetAllNamedSubjects gets the list of subjects that show up in the current named policy.
 func (e *Enforcer) GetAllNamedSubjects(ptype string) ([]string, error) {
-	return e.model.GetValuesForFieldInPolicy("p", ptype, 0)
+	fieldIndex, err := e.model.GetFieldIndex(ptype, constant.SubjectIndex)
+	if err != nil {
+		return nil, err
+	}
+	return e.model.GetValuesForFieldInPolicy("p", ptype, fieldIndex)
 }
 
 // GetAllObjects gets the list of objects that show up in the current policy.
 func (e *Enforcer) GetAllObjects() ([]string, error) {
-	return e.model.GetValuesForFieldInPolicyAllTypes("p", 1)
+	return e.model.GetValuesForFieldInPolicyAllTypesByName("p", constant.ObjectIndex)
 }
 
 // GetAllNamedObjects gets the list of objects that show up in the current named policy.
 func (e *Enforcer) GetAllNamedObjects(ptype string) ([]string, error) {
-	return e.model.GetValuesForFieldInPolicy("p", ptype, 1)
+	fieldIndex, err := e.model.GetFieldIndex(ptype, constant.ObjectIndex)
+	if err != nil {
+		return nil, err
+	}
+	return e.model.GetValuesForFieldInPolicy("p", ptype, fieldIndex)
 }
 
 // GetAllActions gets the list of actions that show up in the current policy.
 func (e *Enforcer) GetAllActions() ([]string, error) {
-	return e.model.GetValuesForFieldInPolicyAllTypes("p", 2)
+	return e.model.GetValuesForFieldInPolicyAllTypesByName("p", constant.ActionIndex)
 }
 
 // GetAllNamedActions gets the list of actions that show up in the current named policy.
 func (e *Enforcer) GetAllNamedActions(ptype string) ([]string, error) {
-	return e.model.GetValuesForFieldInPolicy("p", ptype, 2)
+	fieldIndex, err := e.model.GetFieldIndex(ptype, constant.ActionIndex)
+	if err != nil {
+		return nil, err
+	}
+	return e.model.GetValuesForFieldInPolicy("p", ptype, fieldIndex)
 }
 
 // GetAllRoles gets the list of roles that show up in the current policy.

--- a/management_api_test.go
+++ b/management_api_test.go
@@ -43,6 +43,15 @@ func TestGetList(t *testing.T) {
 	testStringList(t, "Roles", e.GetAllRoles, []string{"data2_admin"})
 }
 
+func TestGetListWithDomains(t *testing.T) {
+	e, _ := NewEnforcer("examples/rbac_with_domains_model.conf", "examples/rbac_with_domains_policy.csv")
+
+	testStringList(t, "Subjects", e.GetAllSubjects, []string{"admin"})
+	testStringList(t, "Objects", e.GetAllObjects, []string{"data1", "data2"})
+	testStringList(t, "Actions", e.GetAllActions, []string{"read", "write"})
+	testStringList(t, "Roles", e.GetAllRoles, []string{"admin"})
+}
+
 func testGetPolicy(t *testing.T, e *Enforcer, res [][]string) {
 	t.Helper()
 	myRes, err := e.GetPolicy()

--- a/model/policy.go
+++ b/model/policy.go
@@ -458,3 +458,25 @@ func (model Model) GetValuesForFieldInPolicyAllTypes(sec string, fieldIndex int)
 
 	return values, nil
 }
+
+// GetValuesForFieldInPolicyAllTypesByName gets all values for a field for all rules in a policy of all ptypes, duplicated values are removed.
+func (model Model) GetValuesForFieldInPolicyAllTypesByName(sec string, field string) ([]string, error) {
+	values := []string{}
+
+	for ptype := range model[sec] {
+		// GetFieldIndex will return (-1, err) if field is not found, ignore it
+		index, err := model.GetFieldIndex(ptype, field)
+		if err != nil {
+			continue
+		}
+		v, err := model.GetValuesForFieldInPolicy(sec, ptype, index)
+		if err != nil {
+			return nil, err
+		}
+		values = append(values, v...)
+	}
+
+	util.ArrayRemoveDuplicates(&values)
+
+	return values, nil
+}


### PR DESCRIPTION
Fix: https://github.com/casbin/casbin/issues/1409

## Short description

- add GetValuesForFieldInPolicyAllTypesByName function to adynamically get fieldIndex for each ptype
- add test for getting objects (subjects and actions are also included) in RBAC with domains mode

## Details

### The root cause

`GetAll{things}` and `GetAllNamed{things}` functions (things can be `actions`, `subjects`, `roles`) use hard-coded `fieldIndex` while fetching the corresponding resources, which causes incorrect behavior when the field indexes change.

According to [the documentation](https://casbin.org/docs/rbac-with-domains), the RBAC mode with domains have the convenient putting `domain` as the second param of a policy, while the `subject` is located at the second param (`fieldIndex=1`) in other mode.

> Note: Conventionally, the domain token name in policy definition is `dom` and is placed as the second token `(sub, dom, obj, act)`. 

### Solution of this PR

To make `casbin` works correctly, the `fieldIndex` of "things"(`actions`, `subjects`, `roles`) should be determined from the config file (instead of hard-coded). 

For `GetAllNamed{things}` functions, the `Model.get_field_index` method is used for getting correct index from config.

For `GetAll{things}`, the `fieldIndex` may be different in different `ptype`. Thus, a new function `GetValuesForFieldInPolicyAllTypesByName` is defined to find `fieldIndex` in different `ptype` by field's name (e.g. `obj`, `act`).

### What's more

#### Changes to documentation

Now `casbin` can detect the position of `dom` and `act` correctly with no extra configuration needed. Setting the field index of `dom` using `SetFieldIndex` API explicitly is no longer necessary. [The document](https://casbin.org/docs/rbac-with-domains) may need to be changed.

#### Similar situation

Now `GetAllRoles` and `GetAllNamedRoles` is still using hard-coded field index (but it won't fail in RBAC with domains mode), this can be optimized using similar API.

Close #1409 