### PR TITLE
feat: CachedEnforcer does not clean the result cached in memory when call ClearPolicy method

### DIFF
--- a/enforcer_cached.go
+++ b/enforcer_cached.go
@@ -182,5 +182,4 @@ func (e *CachedEnforcer) ClearPolicy() {
 		}
 	}
 	e.Enforcer.ClearPolicy()
-	return
 }

--- a/enforcer_cached.go
+++ b/enforcer_cached.go
@@ -172,3 +172,15 @@ func GetCacheKey(params ...interface{}) (string, bool) {
 	}
 	return key.String(), true
 }
+
+// ClearPolicy clears all policy.
+func (e *CachedEnforcer) ClearPolicy() {
+	if atomic.LoadInt32(&e.enableCache) != 0 {
+		if err := e.cache.Clear(); err != nil {
+			e.logger.LogError(err, "clear cache failed")
+			return
+		}
+	}
+	e.Enforcer.ClearPolicy()
+	return
+}

--- a/enforcer_cached_test.go
+++ b/enforcer_cached_test.go
@@ -57,4 +57,17 @@ func TestCache(t *testing.T) {
 	testEnforceCache(t, e, "bob", "data2", "write", false)
 	testEnforceCache(t, e, "alice", "data2", "read", true)
 	testEnforceCache(t, e, "alice", "data2", "write", true)
+
+	e, _ = NewCachedEnforcer("examples/rbac_model.conf", "examples/rbac_policy.csv")
+	testEnforceCache(t, e, "alice", "data1", "read", true)
+	testEnforceCache(t, e, "bob", "data2", "write", true)
+	testEnforceCache(t, e, "alice", "data2", "read", true)
+	testEnforceCache(t, e, "alice", "data2", "write", true)
+
+	e.ClearPolicy()
+
+	testEnforceCache(t, e, "alice", "data1", "read", false)
+	testEnforceCache(t, e, "bob", "data2", "write", false)
+	testEnforceCache(t, e, "alice", "data2", "read", false)
+	testEnforceCache(t, e, "alice", "data2", "write", false)
 }


### PR DESCRIPTION
CachedEnforcer does not clean the result cached in memory when call ClearPolicy method