### PR TITLE
feat: improve performance by pre-compiling regexes

### DIFF
--- a/model/model.go
+++ b/model/model.go
@@ -359,10 +359,14 @@ func (model Model) SortPoliciesByPriority() error {
 	return nil
 }
 
+var (
+	pPattern = regexp.MustCompile("^p_")
+	rPattern = regexp.MustCompile("^r_")
+)
+
 func (model Model) ToText() string {
 	tokenPatterns := make(map[string]string)
 
-	pPattern, rPattern := regexp.MustCompile("^p_"), regexp.MustCompile("^r_")
 	for _, ptype := range []string{"r", "p"} {
 		for _, token := range model[ptype][ptype].Tokens {
 			tokenPatterns[token] = rPattern.ReplaceAllString(pPattern.ReplaceAllString(token, "p."), "r.")

--- a/util/builtin_operators.go
+++ b/util/builtin_operators.go
@@ -31,7 +31,12 @@ import (
 )
 
 var (
-	keyMatch4Re *regexp.Regexp = regexp.MustCompile(`{([^/]+)}`)
+	keyMatch2Re = regexp.MustCompile(`:[^/]+`)
+	keyMatch3Re = regexp.MustCompile(`\{[^/]+\}`)
+	keyMatch4Re = regexp.MustCompile(`{([^/]+)}`)
+	keyMatch5Re = regexp.MustCompile(`\{[^/]+\}`)
+	keyGet2Re1  = regexp.MustCompile(`:[^/]+`)
+	keyGet3Re1  = regexp.MustCompile(`\{[^/]+?\}`) // non-greedy match of `{...}` to support multiple {} in `/.../`
 )
 
 // validate the variadic parameter size and type as string.
@@ -117,8 +122,7 @@ func KeyGetFunc(args ...interface{}) (interface{}, error) {
 func KeyMatch2(key1 string, key2 string) bool {
 	key2 = strings.Replace(key2, "/*", "/.*", -1)
 
-	re := regexp.MustCompile(`:[^/]+`)
-	key2 = re.ReplaceAllString(key2, "$1[^/]+$2")
+	key2 = keyMatch2Re.ReplaceAllString(key2, "$1[^/]+$2")
 
 	return RegexMatch(key1, "^"+key2+"$")
 }
@@ -140,10 +144,8 @@ func KeyMatch2Func(args ...interface{}) (interface{}, error) {
 // if the pathVar == "resource", then "resource1" will be returned.
 func KeyGet2(key1, key2 string, pathVar string) string {
 	key2 = strings.Replace(key2, "/*", "/.*", -1)
-
-	re := regexp.MustCompile(`:[^/]+`)
-	keys := re.FindAllString(key2, -1)
-	key2 = re.ReplaceAllString(key2, "$1([^/]+)$2")
+	keys := keyGet2Re1.FindAllString(key2, -1)
+	key2 = keyGet2Re1.ReplaceAllString(key2, "$1([^/]+)$2")
 	key2 = "^" + key2 + "$"
 	re2 := regexp.MustCompile(key2)
 	values := re2.FindAllStringSubmatch(key1, -1)
@@ -175,9 +177,7 @@ func KeyGet2Func(args ...interface{}) (interface{}, error) {
 // For example, "/foo/bar" matches "/foo/*", "/resource1" matches "/{resource}".
 func KeyMatch3(key1 string, key2 string) bool {
 	key2 = strings.Replace(key2, "/*", "/.*", -1)
-
-	re := regexp.MustCompile(`\{[^/]+\}`)
-	key2 = re.ReplaceAllString(key2, "$1[^/]+$2")
+	key2 = keyMatch3Re.ReplaceAllString(key2, "$1[^/]+$2")
 
 	return RegexMatch(key1, "^"+key2+"$")
 }
@@ -200,9 +200,8 @@ func KeyMatch3Func(args ...interface{}) (interface{}, error) {
 func KeyGet3(key1, key2 string, pathVar string) string {
 	key2 = strings.Replace(key2, "/*", "/.*", -1)
 
-	re := regexp.MustCompile(`\{[^/]+?\}`) // non-greedy match of `{...}` to support multiple {} in `/.../`
-	keys := re.FindAllString(key2, -1)
-	key2 = re.ReplaceAllString(key2, "$1([^/]+?)$2")
+	keys := keyGet3Re1.FindAllString(key2, -1)
+	key2 = keyGet3Re1.ReplaceAllString(key2, "$1([^/]+?)$2")
 	key2 = "^" + key2 + "$"
 	re2 := regexp.MustCompile(key2)
 	values := re2.FindAllStringSubmatch(key1, -1)
@@ -296,9 +295,7 @@ func KeyMatch5(key1 string, key2 string) bool {
 	}
 
 	key2 = strings.Replace(key2, "/*", "/.*", -1)
-
-	re := regexp.MustCompile(`\{[^/]+\}`)
-	key2 = re.ReplaceAllString(key2, "$1[^/]+$2")
+	key2 = keyMatch5Re.ReplaceAllString(key2, "$1[^/]+$2")
 
 	return RegexMatch(key1, "^"+key2+"$")
 }


### PR DESCRIPTION
This PR minimizes the usage of `regexp.MustCompile` by precompiling the static ones and using a cache for dynamic ones.