### PR TITLE
feat: Enforcer config & DefaultLogger customization

### DIFF
--- a/enforcer_cached.go
+++ b/enforcer_cached.go
@@ -36,7 +36,23 @@ type CacheableParam interface {
 	GetCacheKey() string
 }
 
+// NewCachedEnforcerWithConfig creates a cached enforcer via file or DB.
+func NewCachedEnforcerWithConfig(config *EnforcerConfig) (*CachedEnforcer, error) {
+	e := &CachedEnforcer{}
+	var err error
+	e.Enforcer, err = NewEnforcerWithConfig(config)
+	if err != nil {
+		return nil, err
+	}
+
+	e.enableCache = 1
+	e.cache, _ = cache.NewDefaultCache()
+	e.locker = new(sync.RWMutex)
+	return e, nil
+}
+
 // NewCachedEnforcer creates a cached enforcer via file or DB.
+// Deprecated: use NewCachedEnforcerWithConfig instead.
 func NewCachedEnforcer(params ...interface{}) (*CachedEnforcer, error) {
 	e := &CachedEnforcer{}
 	var err error

--- a/enforcer_cached_synced.go
+++ b/enforcer_cached_synced.go
@@ -31,7 +31,23 @@ type SyncedCachedEnforcer struct {
 	locker      *sync.RWMutex
 }
 
+// NewSyncedCachedEnforcerWithConfig creates a sync cached enforcer via file or DB.
+func NewSyncedCachedEnforcerWithConfig(config *EnforcerConfig) (*SyncedCachedEnforcer, error) {
+	e := &SyncedCachedEnforcer{}
+	var err error
+	e.SyncedEnforcer, err = NewSyncedEnforcerWithConfig(config)
+	if err != nil {
+		return nil, err
+	}
+
+	e.enableCache = 1
+	e.cache, _ = cache.NewSyncCache()
+	e.locker = new(sync.RWMutex)
+	return e, nil
+}
+
 // NewSyncedCachedEnforcer creates a sync cached enforcer via file or DB.
+// Deprecated: use NewSyncedCachedEnforcerWithConfig instead.
 func NewSyncedCachedEnforcer(params ...interface{}) (*SyncedCachedEnforcer, error) {
 	e := &SyncedCachedEnforcer{}
 	var err error

--- a/enforcer_distributed.go
+++ b/enforcer_distributed.go
@@ -10,6 +10,19 @@ type DistributedEnforcer struct {
 	*SyncedEnforcer
 }
 
+// NewDistributedEnforcerWithConfig creates a new DistributedEnforcer instance with a config file.
+func NewDistributedEnforcerWithConfig(config *EnforcerConfig) (*DistributedEnforcer, error) {
+	e := &DistributedEnforcer{}
+	var err error
+	e.SyncedEnforcer, err = NewSyncedEnforcerWithConfig(config)
+	if err != nil {
+		return nil, err
+	}
+
+	return e, nil
+}
+
+// Deprecated: use NewDistributedEnforcerWithConfig instead.
 func NewDistributedEnforcer(params ...interface{}) (*DistributedEnforcer, error) {
 	e := &DistributedEnforcer{}
 	var err error

--- a/enforcer_synced.go
+++ b/enforcer_synced.go
@@ -32,7 +32,22 @@ type SyncedEnforcer struct {
 	autoLoadRunning int32
 }
 
+// NewSyncedEnforcerWithConfig creates a synchronized enforcer via file or DB.
+func NewSyncedEnforcerWithConfig(config *EnforcerConfig) (*SyncedEnforcer, error) {
+	e := &SyncedEnforcer{}
+	var err error
+	e.Enforcer, err = NewEnforcerWithConfig(config)
+	if err != nil {
+		return nil, err
+	}
+
+	e.stopAutoLoad = make(chan struct{}, 1)
+	e.autoLoadRunning = 0
+	return e, nil
+}
+
 // NewSyncedEnforcer creates a synchronized enforcer via file or DB.
+// Deprecated: use NewSyncedEnforcerWithConfig instead.
 func NewSyncedEnforcer(params ...interface{}) (*SyncedEnforcer, error) {
 	e := &SyncedEnforcer{}
 	var err error

--- a/log/default_logger.go
+++ b/log/default_logger.go
@@ -23,6 +23,19 @@ import (
 // DefaultLogger is the implementation for a Logger using golang log.
 type DefaultLogger struct {
 	enabled bool
+	Logger  *log.Logger
+}
+
+// NewDefaultLogger creates a new DefaultLogger.
+// If the logger parameter is nil, it will use log.Default().
+func NewDefaultLogger(logger *log.Logger) Logger {
+	if logger == nil {
+		logger = log.Default()
+	}
+	return &DefaultLogger{
+		enabled: false,
+		Logger:  logger,
+	}
 }
 
 func (l *DefaultLogger) EnableLog(enable bool) {
@@ -43,7 +56,7 @@ func (l *DefaultLogger) LogModel(model [][]string) {
 		str.WriteString(fmt.Sprintf("%v\n", v))
 	}
 
-	log.Println(str.String())
+	l.Logger.Println(str.String())
 }
 
 func (l *DefaultLogger) LogEnforce(matcher string, request []interface{}, result bool, explains [][]string) {
@@ -71,7 +84,7 @@ func (l *DefaultLogger) LogEnforce(matcher string, request []interface{}, result
 		}
 	}
 
-	log.Println(reqStr.String())
+	l.Logger.Println(reqStr.String())
 }
 
 func (l *DefaultLogger) LogPolicy(policy map[string][][]string) {
@@ -85,7 +98,7 @@ func (l *DefaultLogger) LogPolicy(policy map[string][][]string) {
 		str.WriteString(fmt.Sprintf("%s : %v\n", k, v))
 	}
 
-	log.Println(str.String())
+	l.Logger.Println(str.String())
 }
 
 func (l *DefaultLogger) LogRole(roles []string) {
@@ -93,12 +106,12 @@ func (l *DefaultLogger) LogRole(roles []string) {
 		return
 	}
 
-	log.Println("Roles: ", strings.Join(roles, "\n"))
+	l.Logger.Println("Roles: ", strings.Join(roles, "\n"))
 }
 
 func (l *DefaultLogger) LogError(err error, msg ...string) {
 	if !l.enabled {
 		return
 	}
-	log.Println(msg, err)
+	l.Logger.Println(msg, err)
 }

--- a/log/log_util.go
+++ b/log/log_util.go
@@ -14,14 +14,14 @@
 
 package log
 
-var logger Logger = &DefaultLogger{}
+var logger Logger = NewDefaultLogger(nil)
 
-// SetLogger sets the current logger.
+// SetLogger sets the current Logger.
 func SetLogger(l Logger) {
 	logger = l
 }
 
-// GetLogger returns the current logger.
+// GetLogger returns the current Logger.
 func GetLogger() Logger {
 	return logger
 }

--- a/log/logger.go
+++ b/log/logger.go
@@ -21,7 +21,7 @@ type Logger interface {
 	// EnableLog controls whether print the message.
 	EnableLog(bool)
 
-	// IsEnabled returns if logger is enabled.
+	// IsEnabled returns if Logger is enabled.
 	IsEnabled() bool
 
 	// LogModel log info related to model.

--- a/model/model.go
+++ b/model/model.go
@@ -142,7 +142,7 @@ func (model Model) GetLogger() log.Logger {
 // NewModel creates an empty model.
 func NewModel() Model {
 	m := make(Model)
-	m.SetLogger(&log.DefaultLogger{})
+	m.SetLogger(log.NewDefaultLogger(nil))
 
 	return m
 }

--- a/rbac/default-role-manager/role_manager.go
+++ b/rbac/default-role-manager/role_manager.go
@@ -211,7 +211,7 @@ func NewRoleManagerImpl(maxHierarchyLevel int) *RoleManagerImpl {
 	rm := RoleManagerImpl{}
 	_ = rm.Clear() // init allRoles and matchingFuncCache
 	rm.maxHierarchyLevel = maxHierarchyLevel
-	rm.SetLogger(&log.DefaultLogger{})
+	rm.SetLogger(log.NewDefaultLogger(nil))
 	return &rm
 }
 
@@ -746,7 +746,7 @@ func NewConditionalRoleManager(maxHierarchyLevel int) *ConditionalRoleManager {
 	rm := ConditionalRoleManager{}
 	_ = rm.Clear() // init allRoles and matchingFuncCache
 	rm.maxHierarchyLevel = maxHierarchyLevel
-	rm.SetLogger(&log.DefaultLogger{})
+	rm.SetLogger(log.NewDefaultLogger(nil))
 	return &rm
 }
 
@@ -904,7 +904,7 @@ func NewConditionalDomainManager(maxHierarchyLevel int) *ConditionalDomainManage
 	rm := ConditionalDomainManager{}
 	_ = rm.Clear() // init allRoles and matchingFuncCache
 	rm.maxHierarchyLevel = maxHierarchyLevel
-	rm.SetLogger(&log.DefaultLogger{})
+	rm.SetLogger(log.NewDefaultLogger(nil))
 	return &rm
 }
 


### PR DESCRIPTION
* Use a config struct for Enforcer creation
* Allow for passing a log.Logger to casbin DefaultLogger

You are now allowed to pass a custom log.Logger to the casbin DefaultLogger. If nil, it'll fallback onto the log.Default() logger (which is the current behavior). Function to init a DefaultLogger is now : casbinlog.NewDefaultLogger(log.Logger)

Refactored NewEnforcer method to a cleaner NewEnforcerWithConfig. This new method takes a EnforcerConfig struct to store the different options for the Enforcer. Old function edited to use the new method, but is still available for backward compatibility.

PR was supposed to be about logs, but I stumbled upon the ugliness of the NewEnforcer function, and went for a small refactor.
Feel free to add or suggest edits.
Pollux