### PR TITLE
fix: addPolicyWithoutNotify() return value when adding duplicated policy

### DIFF
--- a/internal_api.go
+++ b/internal_api.go
@@ -42,7 +42,7 @@ func (e *Enforcer) addPolicyWithoutNotify(sec string, ptype string, rule []strin
 
 	hasPolicy, err := e.model.HasPolicy(sec, ptype, rule)
 	if hasPolicy || err != nil {
-		return hasPolicy, err
+		return false, err
 	}
 
 	if e.shouldPersist() {


### PR DESCRIPTION
The `AddPolicy()` function's comment states that if the enforcer already contains the same policy as the one being added, `AddPolicy()` should `return false, nil`. However, the current implementation does not align with this behavior. This PR updates the code to ensure consistency with the function's intended behavior.