### PR TITLE
fix: align RoleManager behavior with documentation (#1404)

### DIFF
--- a/model_test.go
+++ b/model_test.go
@@ -389,6 +389,12 @@ func (rm *testCustomRoleManager) GetRoles(name string, domain ...string) ([]stri
 func (rm *testCustomRoleManager) GetUsers(name string, domain ...string) ([]string, error) {
 	return []string{}, nil
 }
+func (rm *testCustomRoleManager) GetImplicitRoles(name string, domains ...string) ([]string, error) {
+	return []string{}, nil
+}
+func (rm *testCustomRoleManager) GetImplicitUsers(name string, domains ...string) ([]string, error) {
+	return []string{}, nil
+}
 func (rm *testCustomRoleManager) GetDomains(name string) ([]string, error) {
 	return []string{}, nil
 }

--- a/rbac/default-role-manager/role_manager_test.go
+++ b/rbac/default-role-manager/role_manager_test.go
@@ -431,3 +431,16 @@ func TestConcurrentHasLink(t *testing.T) {
 			inconsistencies, numGoroutines*numIterations)
 	}
 }
+
+func TestAddLink_Cycle(t *testing.T) {
+	rm := NewRoleManager(10)
+	_ = rm.AddLink("a", "b")
+	_ = rm.AddLink("b", "c")
+	err := rm.AddLink("c", "a")
+
+	if err == nil {
+		t.Errorf("Expected an error when creating a cycle, but got nil")
+	} else {
+		t.Logf("Successfully detected cycle: %s", err)
+	}
+}

--- a/rbac/role_manager.go
+++ b/rbac/role_manager.go
@@ -41,6 +41,10 @@ type RoleManager interface {
 	// GetUsers gets the users that inherits a role.
 	// domain is a prefix to the users (can be used for other purposes).
 	GetUsers(name string, domain ...string) ([]string, error)
+
+	GetImplicitRoles(name string, domains ...string) ([]string, error)
+
+	GetImplicitUsers(name string, domains ...string) ([]string, error)
 	// GetDomains gets domains that a user has
 	GetDomains(name string) ([]string, error)
 	// GetAllDomains gets all domains


### PR DESCRIPTION
This PR introduces a level field to the Role struct and updates the RoleManager to dynamically maintain this field.
It ensures that maxHierarchyLevel not only limits the depth of the HasLink function, but also applies to other role traversal  such as:
GetImplicitRolesForUser
GetImplicitUsersForRole

Why this change is necessary
Previously, maxHierarchyLevel only affected HasLink, while other functions could traverse indefinitely, which led to inconsistencies between the documented behavior and actual implementation.
This update:
Makes the behavior of RoleManager consistent with the documentation
Keeps the change self-contained within RoleManager, without requiring modifications to external components
Ensures all relevant traversal functions now honor the maxHierarchyLevel setting

Summary of Changes
Added level field to Role struct
Dynamically maintained level values within RoleManager
Applied hierarchy level checks consistently across relevant APIs