### PR TITLE
feat: change PolicyMap from nomal map to sync.map (#1495)

### DIFF
--- a/model/model.go
+++ b/model/model.go
@@ -22,6 +22,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/casbin/casbin/v2/config"
 	"github.com/casbin/casbin/v2/constant"
@@ -75,7 +76,7 @@ func (model Model) AddDef(sec string, key string, value string) bool {
 	ast := Assertion{}
 	ast.Key = key
 	ast.Value = value
-	ast.PolicyMap = make(map[string]int)
+	ast.PolicyMap = sync.Map{}
 	ast.FieldIndexMap = make(map[string]int)
 	ast.setLogger(model.GetLogger())
 
@@ -273,7 +274,7 @@ func (model Model) SortPoliciesBySubjectHierarchy() error {
 			return p1 > p2
 		})
 		for i, policy := range assertion.Policy {
-			assertion.PolicyMap[strings.Join(policy, ",")] = i
+			assertion.PolicyMap.Store(strings.Join(policy, ","), i)
 		}
 	}
 	return nil
@@ -353,7 +354,7 @@ func (model Model) SortPoliciesByPriority() error {
 			return p1 < p2
 		})
 		for i, policy := range assertion.Policy {
-			assertion.PolicyMap[strings.Join(policy, ",")] = i
+			assertion.PolicyMap.Store(strings.Join(policy, ","), i)
 		}
 	}
 	return nil


### PR DESCRIPTION
feat: change PolicyMap from nomal map to sync.map (#1495), may  have some help.

I couldn't reproduce the issue on my side, but I suspect it might be due to the lock granularity in SyncedEnforcer, or maybe some methods are being called inside a locked context and then call other functions that aren't aware of the lock.

My proposed solution is to change Assertion.PolicyMap from a map[string]int to a sync.Map, which seems to fix the problem. But it does have a noticeable impact on performance—overall benchmark performance drops by about 3%, and BenchmarkAddPolicy and BenchmarkRemovePolicy drop by 10–46%.

So it's really a trade-off.