### PR TITLE
fix: proper concurrent access to field map cache

### DIFF
--- a/internal_api.go
+++ b/internal_api.go
@@ -493,5 +493,5 @@ func (e *Enforcer) GetFieldIndex(ptype string, field string) (int, error) {
 
 func (e *Enforcer) SetFieldIndex(ptype string, field string, index int) {
 	assertion := e.model["p"][ptype]
-	assertion.FieldIndexMap[field] = index
+	assertion.FieldIndexMap.Store(field, index)
 }

--- a/model/model.go
+++ b/model/model.go
@@ -76,7 +76,6 @@ func (model Model) AddDef(sec string, key string, value string) bool {
 	ast.Key = key
 	ast.Value = value
 	ast.PolicyMap = make(map[string]int)
-	ast.FieldIndexMap = make(map[string]int)
 	ast.setLogger(model.GetLogger())
 
 	if sec == "r" || sec == "p" {
@@ -419,7 +418,7 @@ func (model Model) Copy() Model {
 
 func (model Model) GetFieldIndex(ptype string, field string) (int, error) {
 	assertion := model["p"][ptype]
-	if index, ok := assertion.FieldIndexMap[field]; ok {
+	if index, ok := assertion.GetFieldIndex(field); ok {
 		return index, nil
 	}
 	pattern := fmt.Sprintf("%s_"+field, ptype)
@@ -433,6 +432,6 @@ func (model Model) GetFieldIndex(ptype string, field string) (int, error) {
 	if index == -1 {
 		return index, fmt.Errorf(field + " index is not set, please use enforcer.SetFieldIndex() to set index")
 	}
-	assertion.FieldIndexMap[field] = index
+	assertion.FieldIndexMap.Store(field, index)
 	return index, nil
 }

--- a/model/policy.go
+++ b/model/policy.go
@@ -229,14 +229,15 @@ func (model Model) AddPolicy(sec string, ptype string, rule []string) error {
 	assertion.PolicyMap[strings.Join(rule, DefaultSep)] = len(model[sec][ptype].Policy) - 1
 
 	hasPriority := false
-	if _, ok := assertion.FieldIndexMap[constant.PriorityIndex]; ok {
+	if _, ok := assertion.FieldIndexMap.Load(constant.PriorityIndex); ok {
 		hasPriority = true
 	}
 	if sec == "p" && hasPriority {
-		if idxInsert, err := strconv.Atoi(rule[assertion.FieldIndexMap[constant.PriorityIndex]]); err == nil {
+		priorityIndex := assertion.GetFieldIndexOrZero(constant.PriorityIndex)
+		if idxInsert, err := strconv.Atoi(rule[priorityIndex]); err == nil {
 			i := len(assertion.Policy) - 1
 			for ; i > 0; i-- {
-				idx, err := strconv.Atoi(assertion.Policy[i-1][assertion.FieldIndexMap[constant.PriorityIndex]])
+				idx, err := strconv.Atoi(assertion.Policy[i-1][priorityIndex])
 				if err != nil || idx <= idxInsert {
 					break
 				}


### PR DESCRIPTION
Fixes #1514 

It replaces the field index map by a synchronized map (optimized for cache pattern accesses) to allow concurrent reads of the field index.