### PR TITLE
feat: add mutex protection for FieldIndexMap to prevent concurrent writes

### DIFF
--- a/internal_api.go
+++ b/internal_api.go
@@ -493,5 +493,7 @@ func (e *Enforcer) GetFieldIndex(ptype string, field string) (int, error) {
 
 func (e *Enforcer) SetFieldIndex(ptype string, field string, index int) {
 	assertion := e.model["p"][ptype]
+	assertion.FieldIndexMutex.Lock()
 	assertion.FieldIndexMap[field] = index
+	assertion.FieldIndexMutex.Unlock()
 }

--- a/model/model.go
+++ b/model/model.go
@@ -419,9 +419,14 @@ func (model Model) Copy() Model {
 
 func (model Model) GetFieldIndex(ptype string, field string) (int, error) {
 	assertion := model["p"][ptype]
+
+	assertion.FieldIndexMutex.RLock()
 	if index, ok := assertion.FieldIndexMap[field]; ok {
+		assertion.FieldIndexMutex.RUnlock()
 		return index, nil
 	}
+	assertion.FieldIndexMutex.RUnlock()
+
 	pattern := fmt.Sprintf("%s_"+field, ptype)
 	index := -1
 	for i, token := range assertion.Tokens {
@@ -433,6 +438,10 @@ func (model Model) GetFieldIndex(ptype string, field string) (int, error) {
 	if index == -1 {
 		return index, fmt.Errorf(field + " index is not set, please use enforcer.SetFieldIndex() to set index")
 	}
+
+	assertion.FieldIndexMutex.Lock()
 	assertion.FieldIndexMap[field] = index
+	assertion.FieldIndexMutex.Unlock()
+
 	return index, nil
 }


### PR DESCRIPTION
## Fix concurrent writes on assertion

### Problem
Fixes [concurrent writes on assertion #1514](https://github.com/casbin/casbin/issues/1514)

The issue was caused by concurrent access to `FieldIndexMap` in the `Assertion` struct, which could lead to "concurrent map writes" panic when multiple goroutines simultaneously call `GetFieldIndex()`.

### Changes
- `model/assertion.go`: Added mutex field and protected copy operation
- `model/model.go`: Added read/write lock protection in `GetFieldIndex`
- `internal_api.go`: Added write lock protection in `SetFieldIndex`

Closes #1514