### PR TITLE
fix(Casbin): fix a bug in UpdateFilteredPolicies()

### DIFF
--- a/internal_api.go
+++ b/internal_api.go
@@ -274,8 +274,9 @@ func (e *Enforcer) removeFilteredPolicyWithoutNotify(sec string, ptype string, f
 
 func (e *Enforcer) updateFilteredPoliciesWithoutNotify(sec string, ptype string, newRules [][]string, fieldIndex int, fieldValues ...string) ([][]string, error) {
 	var (
-		oldRules [][]string
-		err      error
+		oldRules    [][]string
+		err         error
+		ruleChanged bool
 	)
 
 	if _, err = e.model.GetAssertion(sec, ptype); err != nil {
@@ -300,9 +301,11 @@ func (e *Enforcer) updateFilteredPoliciesWithoutNotify(sec string, ptype string,
 		return oldRules, e.dispatcher.UpdateFilteredPolicies(sec, ptype, oldRules, newRules)
 	}
 	if len(oldRules) == 0 {
-		oldRules = append(oldRules, fieldValues)
+		ruleChanged, oldRules, err = e.model.RemoveFilteredPolicy(sec, ptype, fieldIndex, fieldValues...)
+		if err != nil {
+			return oldRules, err
+		}
 	}
-	ruleChanged, err := e.model.RemovePolicies(sec, ptype, oldRules)
 	if err != nil {
 		return oldRules, err
 	}


### PR DESCRIPTION
Fixed an issue where the UpdateFilteredPolicies() function failed to implement update functionality when persistence was not implemented.
This is the specific error report (a Chinese version of the documentation):https://www.notion.so/2b14b208901680f39ee4ec36a3688990?source=copy_link