### PR TITLE
fix: remove deprecated comment from RemovePolicy method

### DIFF
--- a/model/policy.go
+++ b/model/policy.go
@@ -253,7 +253,6 @@ func (model Model) AddPoliciesWithAffected(sec string, ptype string, rules [][]s
 }
 
 // RemovePolicy removes a policy rule from the model.
-// Deprecated: Using AddPoliciesWithAffected instead.
 func (model Model) RemovePolicy(sec string, ptype string, rule []string) (bool, error) {
 	ast, err := model.GetAssertion(sec, ptype)
 	if err != nil {


### PR DESCRIPTION
This PR fixes an incorrect deprecation comment in the RemovePolicy method.
The current comment states:
```go
// RemovePolicy removes a policy rule from the model.
// Deprecated: Using AddPoliciesWithAffected instead.
func (model Model) RemovePolicy(sec string, ptype string, rule []string) (bool, error) {
	...
}
```
However, this is incorrect because:
1. RemovePolicy is used to remove a single policy rule
2. AddPoliciesWithAffected is used to add policy rules
3. These functions have completely different purposes - one removes while the other adds

The deprecation comment has been removed as it was providing incorrect guidance to users of the API.
Note: This issue exists in both v2 and v3 versions of the library.