### PR TITLE
feat: perf(enforce): reuse buffers with sync.Pool to reduce allocations

### DIFF
--- a/enforcer.go
+++ b/enforcer.go
@@ -844,12 +844,6 @@ func (e *Enforcer) enforce(matcher string, explains *[]string, rvals ...interfac
 			e.putPolicyEffectsBuffer(policyEffectsBuffer)
 			e.putMatcherResultsBuffer(matcherResultsBuffer)
 		}()
-		for i := range matcherResults {
-			matcherResults[i] = 0
-		}
-		for i := range policyEffects {
-			policyEffects[i] = 0
-		}
 
 		for policyIndex, pvals := range e.model["p"][pType].Policy {
 			// log.LogPrint("Policy Rule: ", pvals)


### PR DESCRIPTION
Local profiling on current  master branch showed alloc_space hotspots dominated by make slices inside enforce. Heap profiles traced most churn to policyEffects and matcherResults buffers.
- The fix replaces per-call allocations with sync.pool reuse for both buffers. It reduces gc pressure and stabilizes allocation behavior under load.
- Global pools are used to avoid inflating the enforcer struct and to keep cache layout stable. Buffers are zeroed before use to prevent stale data effects.
- Bench results show a ~26% drop in bytes/op for rbacModelWithDomainPatternLarge. Allocs/op fall ~11% in cachedAbacModel, basicModel, and abacModel.