### PR TITLE
perf: optimize KeyMatch functions with fast path for wildcard replacement

### DIFF
--- a/util/builtin_operators.go
+++ b/util/builtin_operators.go
@@ -137,7 +137,9 @@ func KeyGetFunc(args ...interface{}) (interface{}, error) {
 // KeyMatch2 determines whether key1 matches the pattern of key2 (similar to RESTful path), key2 can contain a *.
 // For example, "/foo/bar" matches "/foo/*", "/resource1" matches "/:resource".
 func KeyMatch2(key1 string, key2 string) bool {
-	key2 = strings.Replace(key2, "/*", "/.*", -1)
+	if strings.Contains(key2, "/*") { //nolint:gosimple // optimization
+		key2 = strings.Replace(key2, "/*", "/.*", -1)
+	}
 
 	key2 = keyMatch2Re.ReplaceAllString(key2, "$1[^/]+$2")
 
@@ -160,7 +162,9 @@ func KeyMatch2Func(args ...interface{}) (interface{}, error) {
 // For example, "/resource1" matches "/:resource"
 // if the pathVar == "resource", then "resource1" will be returned.
 func KeyGet2(key1, key2 string, pathVar string) string {
-	key2 = strings.Replace(key2, "/*", "/.*", -1)
+	if strings.Contains(key2, "/*") { //nolint:gosimple // optimization
+		key2 = strings.Replace(key2, "/*", "/.*", -1)
+	}
 	keys := keyGet2Re1.FindAllString(key2, -1)
 	key2 = keyGet2Re1.ReplaceAllString(key2, "$1([^/]+)$2")
 	key2 = "^" + key2 + "$"
@@ -194,7 +198,9 @@ func KeyGet2Func(args ...interface{}) (interface{}, error) {
 // KeyMatch3 determines whether key1 matches the pattern of key2 (similar to RESTful path), key2 can contain a *.
 // For example, "/foo/bar" matches "/foo/*", "/resource1" matches "/{resource}".
 func KeyMatch3(key1 string, key2 string) bool {
-	key2 = strings.Replace(key2, "/*", "/.*", -1)
+	if strings.Contains(key2, "/*") { //nolint:gosimple // optimization
+		key2 = strings.Replace(key2, "/*", "/.*", -1)
+	}
 	key2 = keyMatch3Re.ReplaceAllString(key2, "$1[^/]+$2")
 
 	return RegexMatch(key1, "^"+key2+"$")
@@ -216,7 +222,9 @@ func KeyMatch3Func(args ...interface{}) (interface{}, error) {
 // For example, "project/proj_project1_admin/" matches "project/proj_{project}_admin/"
 // if the pathVar == "project", then "project1" will be returned.
 func KeyGet3(key1, key2 string, pathVar string) string {
-	key2 = strings.Replace(key2, "/*", "/.*", -1)
+	if strings.Contains(key2, "/*") { //nolint:gosimple // optimization
+		key2 = strings.Replace(key2, "/*", "/.*", -1)
+	}
 
 	keys := keyGet3Re1.FindAllString(key2, -1)
 	key2 = keyGet3Re1.ReplaceAllString(key2, "$1([^/]+?)$2")
@@ -253,7 +261,9 @@ func KeyGet3Func(args ...interface{}) (interface{}, error) {
 // "/parent/123/child/456" does not match "/parent/{id}/child/{id}"
 // But KeyMatch3 will match both.
 func KeyMatch4(key1 string, key2 string) bool {
-	key2 = strings.Replace(key2, "/*", "/.*", -1)
+	if strings.Contains(key2, "/*") { //nolint:gosimple // optimization
+		key2 = strings.Replace(key2, "/*", "/.*", -1)
+	}
 
 	tokens := []string{}
 
@@ -312,7 +322,9 @@ func KeyMatch5(key1 string, key2 string) bool {
 		key1 = key1[:i]
 	}
 
-	key2 = strings.Replace(key2, "/*", "/.*", -1)
+	if strings.Contains(key2, "/*") { //nolint:gosimple // optimization
+		key2 = strings.Replace(key2, "/*", "/.*", -1)
+	}
 	key2 = keyMatch5Re.ReplaceAllString(key2, "$1[^/]+$2")
 
 	return RegexMatch(key1, "^"+key2+"$")


### PR DESCRIPTION
This pull request optimizes the performance of path matching functions in the utility package.

- The casbin library heavily relies on functions like KeyMatch2 through KeyMatch5 for policy enforcement.
- Profiling analysis revealed that strings.Replace was executing unconditionally, consuming unnecessary CPU cycles.
- We implemented a fast path check using strings.Contains to verify wildcard existence before attempting replacement.
- This engineering change effectively reduces overhead for keys that do not require modification.
- The optimization is validated against upstream benchmarks, specifically BenchmarkRBACModelWithDomainPatternLarge .
- Linter directives //nolint:gosimple are added to explain the intentional code structure for performance gains.