### PR TITLE
perf: optimize token index lookup in enforcer

### DIFF
--- a/enforcer.go
+++ b/enforcer.go
@@ -740,14 +740,8 @@ func (e *Enforcer) enforce(matcher string, explains *[]string, rvals ...interfac
 		expString = util.EscapeStringLiterals(util.RemoveComments(util.EscapeAssertion(matcher)))
 	}
 
-	rTokens := make(map[string]int, len(e.model["r"][rType].Tokens))
-	for i, token := range e.model["r"][rType].Tokens {
-		rTokens[token] = i
-	}
-	pTokens := make(map[string]int, len(e.model["p"][pType].Tokens))
-	for i, token := range e.model["p"][pType].Tokens {
-		pTokens[token] = i
-	}
+	rTokens := e.model["r"][rType].TokenIndexMap
+	pTokens := e.model["p"][pType].TokenIndexMap
 
 	if e.acceptJsonRequest {
 		// try to parse all request values from json to map[string]interface{}

--- a/management_api.go
+++ b/management_api.go
@@ -167,10 +167,7 @@ func (e *Enforcer) GetFilteredNamedPolicyWithMatcher(ptype string, matcher strin
 		return res, err
 	}
 
-	pTokens := make(map[string]int, len(e.model["p"][ptype].Tokens))
-	for i, token := range e.model["p"][ptype].Tokens {
-		pTokens[token] = i
-	}
+	pTokens := e.model["p"][ptype].TokenIndexMap
 
 	parameters := enforceParameters{
 		pTokens: pTokens,

--- a/model/assertion.go
+++ b/model/assertion.go
@@ -35,6 +35,7 @@ type Assertion struct {
 	CondRM          rbac.ConditionalRoleManager
 	FieldIndexMap   map[string]int
 	FieldIndexMutex sync.RWMutex
+	TokenIndexMap   map[string]int
 }
 
 func (ast *Assertion) buildIncrementalRoleLinks(rm rbac.RoleManager, op PolicyOp, rules [][]string) error {
@@ -193,6 +194,13 @@ func (ast *Assertion) copy() *Assertion {
 		ParamsTokens:  append([]string(nil), ast.ParamsTokens...),
 		RM:            ast.RM,
 		CondRM:        ast.CondRM,
+	}
+
+	if ast.TokenIndexMap != nil {
+		newAst.TokenIndexMap = make(map[string]int)
+		for k, v := range ast.TokenIndexMap {
+			newAst.TokenIndexMap[k] = v
+		}
 	}
 
 	return newAst

--- a/model/model.go
+++ b/model/model.go
@@ -80,13 +80,19 @@ func (model Model) AddDef(sec string, key string, value string) bool {
 
 	if sec == "r" || sec == "p" {
 		ast.Tokens = strings.Split(ast.Value, ",")
+		ast.TokenIndexMap = make(map[string]int, len(ast.Tokens))
 		for i := range ast.Tokens {
 			ast.Tokens[i] = key + "_" + strings.TrimSpace(ast.Tokens[i])
+			ast.TokenIndexMap[ast.Tokens[i]] = i
 		}
 	} else if sec == "g" {
 		ast.ParamsTokens = getParamsToken(ast.Value)
 		ast.Tokens = strings.Split(ast.Value, ",")
 		ast.Tokens = ast.Tokens[:len(ast.Tokens)-len(ast.ParamsTokens)]
+		ast.TokenIndexMap = make(map[string]int, len(ast.Tokens))
+		for i, token := range ast.Tokens {
+			ast.TokenIndexMap[token] = i
+		}
 	} else {
 		ast.Value = util.RemoveComments(util.EscapeAssertion(ast.Value))
 	}

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -119,9 +119,38 @@ func TestModel_AddDef(t *testing.T) {
 	if !ok {
 		t.Errorf("non empty assertion should be added")
 	}
+
+	ast := m["r"]["r"]
+	if len(ast.TokenIndexMap) != 3 {
+		t.Errorf("TokenIndexMap length should be 3, got %d", len(ast.TokenIndexMap))
+	}
+	if ast.TokenIndexMap["r_sub"] != 0 || ast.TokenIndexMap["r_obj"] != 1 || ast.TokenIndexMap["r_act"] != 2 {
+		t.Errorf("TokenIndexMap values are incorrect: %v", ast.TokenIndexMap)
+	}
+
 	ok = m.AddDef(s, s, "")
 	if ok {
 		t.Errorf("empty assertion value should not be added")
+	}
+}
+
+func TestAssertion_Copy(t *testing.T) {
+	m := NewModel()
+	_ = m.AddDef("r", "r", "sub, obj, act")
+	ast := m["r"]["r"]
+	newAst := ast.copy()
+
+	if len(newAst.TokenIndexMap) != 3 {
+		t.Errorf("Copied TokenIndexMap length should be 3, got %d", len(newAst.TokenIndexMap))
+	}
+	if newAst.TokenIndexMap["r_sub"] != 0 || newAst.TokenIndexMap["r_obj"] != 1 || newAst.TokenIndexMap["r_act"] != 2 {
+		t.Errorf("Copied TokenIndexMap values are incorrect: %v", newAst.TokenIndexMap)
+	}
+
+	// Verify it's a deep copy
+	newAst.TokenIndexMap["r_sub"] = 10
+	if ast.TokenIndexMap["r_sub"] != 0 {
+		t.Errorf("Deep copy failed, modifying copy affected original")
 	}
 }
 


### PR DESCRIPTION
This PR optimizes the Casbin enforcer's performance by caching token index mappings, reducing redundant computations during policy enforcement.

- Pre-computation: Implemented TokenIndexMap within the Assertion struct to cache token indices upon model loading, avoiding repetitive loop lookups.
- Direct Access: Updated enforce logic and management APIs to utilize the cached map instead of reconstructing it for every request.
- Model Initialization: Modified model.go to populate the index map during the parsing of r , p , and g definitions.
- Deep Copy Support: Enhanced the Assertion.copy method to ensure thread-safe deep copying of the new index map.
- Verification: Added unit tests to validate map initialization correctness and deep copy integrity.

This optimization significantly lowers the overhead for high-throughput policy checks.