### PR TITLE
fix: GitHub homepage URL (casbin.apache.org 404 → casbin.org)

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -20,7 +20,7 @@
 github:
   description: >-
     Apache Casbin: an authorization library that supports access control models like ACL, RBAC, ABAC.
-  homepage: https://casbin.apache.org/
+  homepage: https://casbin.org/
   dependabot_alerts:  true
   dependabot_updates: false
 


### PR DESCRIPTION
## Problem
The repository `homepage` in [`.asf.yaml`](https://github.com/apache/casbin/blob/master/.asf.yaml) is set to `https://casbin.apache.org/`. That URL currently returns **HTTP 404** (Not Found).

## Change
Update `github.homepage` to **https://casbin.org/** — the live project site ([Apache Casbin](https://casbin.org)).

This aligns the GitHub "About" link with the URLs already used throughout `README.md` (docs, editor, etc.).