### PR TITLE
Fix: Treat "*" as explicit wildcard instead of "".

### DIFF
--- a/management_api_test.go
+++ b/management_api_test.go
@@ -177,8 +177,8 @@ func TestGetPolicyAPI(t *testing.T) {
 		{"data2_admin", "data2", "write"}})
 
 	testGetFilteredPolicy(t, e, 0, [][]string{{"data2_admin", "data2", "read"}, {"data2_admin", "data2", "write"}}, "data2_admin", "data2")
-	// Note: "" (empty string) in fieldValues means matching all values.
-	testGetFilteredPolicy(t, e, 0, [][]string{{"data2_admin", "data2", "read"}}, "data2_admin", "", "read")
+	// Note: "*" (asterisk) in fieldValues means matching all values.
+	testGetFilteredPolicy(t, e, 0, [][]string{{"data2_admin", "data2", "read"}}, "data2_admin", "*", "read")
 	testGetFilteredPolicy(t, e, 1, [][]string{{"bob", "data2", "write"}, {"data2_admin", "data2", "write"}}, "data2", "write")
 
 	testHasPolicy(t, e, []string{"alice", "data1", "read"}, true)
@@ -192,8 +192,8 @@ func TestGetPolicyAPI(t *testing.T) {
 	testGetFilteredGroupingPolicy(t, e, 0, [][]string{}, "bob")
 	testGetFilteredGroupingPolicy(t, e, 1, [][]string{}, "data1_admin")
 	testGetFilteredGroupingPolicy(t, e, 1, [][]string{{"alice", "data2_admin"}}, "data2_admin")
-	// Note: "" (empty string) in fieldValues means matching all values.
-	testGetFilteredGroupingPolicy(t, e, 0, [][]string{{"alice", "data2_admin"}}, "", "data2_admin")
+	// Note: "*" (asterisk) in fieldValues means matching all values.
+	testGetFilteredGroupingPolicy(t, e, 0, [][]string{{"alice", "data2_admin"}}, "*", "data2_admin")
 
 	testHasGroupingPolicy(t, e, []string{"alice", "data2_admin"}, true)
 	testHasGroupingPolicy(t, e, []string{"bob", "data2_admin"}, false)

--- a/model/policy.go
+++ b/model/policy.go
@@ -127,7 +127,11 @@ func (model Model) GetFilteredPolicy(sec string, ptype string, fieldIndex int, f
 	for _, rule := range model[sec][ptype].Policy {
 		matched := true
 		for i, fieldValue := range fieldValues {
+<<<<<<< Updated upstream
 			if fieldValue != "" && rule[fieldIndex+i] != fieldValue {
+=======
+			if fieldValue != "*" && rule[fieldIndex+i] != fieldValue {
+>>>>>>> Stashed changes
 				matched = false
 				break
 			}
@@ -379,7 +383,7 @@ func (model Model) RemoveFilteredPolicy(sec string, ptype string, fieldIndex int
 	for _, rule := range model[sec][ptype].Policy {
 		matched := true
 		for i, fieldValue := range fieldValues {
-			if fieldValue != "" && rule[fieldIndex+i] != fieldValue {
+			if fieldValue != "*" && rule[fieldIndex+i] != fieldValue {
 				matched = false
 				break
 			}

--- a/rbac_api.go
+++ b/rbac_api.go
@@ -99,7 +99,7 @@ func (e *Enforcer) DeleteRolesForUser(user string, domain ...string) (bool, erro
 	} else if len(domain) > 1 {
 		return false, errors.ErrDomainParameter
 	} else {
-		args = []string{user, "", domain[0]}
+		args = []string{user, "*", domain[0]}
 	}
 	return e.RemoveFilteredGroupingPolicy(0, args...)
 }
@@ -194,6 +194,10 @@ func (e *Enforcer) GetNamedPermissionsForUser(ptype string, user string, domain 
 			continue
 		}
 		args := make([]string, len(assertion.Tokens))
+		// Fill all fields with "*" by default
+		for i := range args {
+			args[i] = "*"
+		}
 		subIndex, err := e.GetFieldIndex("p", constant.SubjectIndex)
 		if err != nil {
 			subIndex = 0

--- a/rbac_api_context.go
+++ b/rbac_api_context.go
@@ -48,7 +48,7 @@ func (e *ContextEnforcer) DeleteRolesForUserCtx(ctx context.Context, user string
 	} else if len(domain) > 1 {
 		return false, errors.ErrDomainParameter
 	} else {
-		args = []string{user, "", domain[0]}
+		args = []string{user, "*", domain[0]}
 	}
 	return e.RemoveFilteredGroupingPolicyCtx(ctx, 0, args...)
 }


### PR DESCRIPTION
This aligns with standard adapter behaviour, allowing "" to act as a literal value.

Fixes #1708 

Note: This is a breaking change for anyone using empty strings as wildcards, but is consistent with the standardized adapter behaviour discussed in #316 . 

As discussed in #316 ,  Adapters should/do support empty string values in rules in database. GetFilteredPolicy/RemoveFilteredPolicy couldn't properly handle those rules with empty string values in database due to empty strings being treated as wildcards.

Tests pass