### PR TITLE
perf: pre-compile regex in RegexMatch for better performance

### DIFF
--- a/util/builtin_operators.go
+++ b/util/builtin_operators.go
@@ -332,11 +332,7 @@ func KeyMatch5Func(args ...interface{}) (interface{}, error) {
 
 // RegexMatch determines whether key1 matches the pattern of key2 in regular expression.
 func RegexMatch(key1 string, key2 string) bool {
-	res, err := regexp.MatchString(key2, key1)
-	if err != nil {
-		panic(err)
-	}
-	return res
+	return mustCompileOrGet(key2).MatchString(key1)
 }
 
 // RegexMatchFunc is the wrapper for RegexMatch.


### PR DESCRIPTION
## Summary

Ref #1690

`RegexMatch()` used `regexp.MatchString()` which recompiles the regex pattern on **every single invocation**. This is a performance bottleneck since `RegexMatch` is called by `KeyMatch2`, `KeyMatch3`, `KeyMatch5`, and can be used directly in policy matchers.

## Change

Replaced `regexp.MatchString()` with the existing `mustCompileOrGet()` cache that is already used throughout the codebase for other KeyMatch functions. The compiled regex is cached in a thread-safe map and reused on subsequent calls.

```go
// Before: recompiles regex on every call
func RegexMatch(key1 string, key2 string) bool {
    res, err := regexp.MatchString(key2, key1)
    if err != nil {
        panic(err)
    }
    return res
}

// After: uses cached compiled regex
func RegexMatch(key1 string, key2 string) bool {
    return mustCompileOrGet(key2).MatchString(key1)
}
```

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` — all tests pass
- [x] `go test ./util/...` — all util tests pass including regex match tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)