### PR TITLE
fix: preserve non-ASCII literals in EscapeStringLiterals

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -285,9 +285,7 @@ func EscapeStringLiterals(expr string) string {
 	inString := false
 	var quote rune
 
-	for i := 0; i < len(expr); i++ {
-		ch := rune(expr[i])
-
+	for _, ch := range expr {
 		if inString {
 			result.WriteRune(ch)
 			if ch == '\\' {

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -254,6 +254,11 @@ func TestEscapeStringLiterals(t *testing.T) {
 	testEscapeStringLiterals(t, `regexMatch("\1\2", p.obj)`, `regexMatch("\\1\\2", p.obj)`)
 	testEscapeStringLiterals(t, `r.sub == '\test'`, `r.sub == '\\test'`)
 
+	// Test that non-ASCII (multi-byte UTF-8) string literals are preserved
+	testEscapeStringLiterals(t, `r.sub == '香港'`, `r.sub == '香港'`)
+	testEscapeStringLiterals(t, `r.obj == "café"`, `r.obj == "café"`)
+	testEscapeStringLiterals(t, `keyMatch(r.obj, 'naïve\1')`, `keyMatch(r.obj, 'naïve\\1')`)
+
 	// Test expressions without string literals
 	testEscapeStringLiterals(t, `r.sub == p.sub`, `r.sub == p.sub`)
 	testEscapeStringLiterals(t, `keyMatch(r.obj, p.obj)`, `keyMatch(r.obj, p.obj)`)


### PR DESCRIPTION
### What

`EscapeStringLiterals` iterated the matcher expression **byte-by-byte** and re-encoded each byte as a rune:

```go
for i := 0; i < len(expr); i++ {
    ch := rune(expr[i])
    ...
    result.WriteRune(ch)
}
```

For any multi-byte UTF-8 character, every continuation byte (`0x80`–`0xFF`) was written out as its own code point, corrupting the literal:

```
EscapeStringLiterals(`r.sub == '香港'`) => `r.sub == 'é¦\x99æ¸¯'`   // 17 -> 23 bytes
```

This runs at model-load time (`model.go` `loadAssertion`) and inside `EnforceWithMatcher`, so a matcher containing a non-ASCII string literal silently stopped matching the real request value — i.e. **wrong allow/deny decisions** for any policy or matcher using non-ASCII literals.

### Fix

Iterate over runes (`for _, ch := range expr`) so multi-byte characters round-trip unchanged. The backslash-doubling and quote-tracking logic is unchanged. Added regression cases for CJK and accented literals to `TestEscapeStringLiterals`.

`go test ./util/ -run TestEscapeStringLiterals` fails before this change (the new cases) and passes after; the full `util` package tests pass, `go vet` and `gofmt` are clean.
